### PR TITLE
Bug fixes and some small fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "icann-rdap-cli"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1221,7 +1221,7 @@ dependencies = [
 
 [[package]]
 name = "icann-rdap-client"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "buildstructor",
  "chrono",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "icann-rdap-common"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "buildstructor",
  "chrono",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "icann-rdap-srv"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1211,11 +1211,11 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "simplelog",
  "termimad",
  "test_dir",
  "thiserror",
  "tokio",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -1635,15 +1635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "object"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,12 +1717,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "paris"
-version = "1.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fecab3723493c7851f292cb060f3ee1c42f19b8d749345d0d7eaf3fd19aa62d"
 
 [[package]]
 name = "parking_lot"
@@ -2378,18 +2363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simplelog"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acee08041c5de3d5048c8b3f6f13fafb3026b24ba43c6a695a0c76179b844369"
-dependencies = [
- "log",
- "paris",
- "termcolor",
- "time",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,15 +2595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "termimad"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,35 +2660,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.3.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
- "serde",
- "time-core",
- "time-macros",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
-
-[[package]]
-name = "time-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
-dependencies = [
- "time-core",
 ]
 
 [[package]]
@@ -3212,15 +3147,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,9 +106,6 @@ serde = { version = "1.0", features = [ "derive" ] }
 # json serializer
 serde_json = "1.0"
 
-# simple log framework
-simplelog = { version = "0.12", features = ["paris"] }
-
 # sqlx (async db)
 sqlx = { version = "0.6", features = [
     "runtime-tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/icann/icann-rdap"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 ICANN RDAP
 ==========
 
-This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers (ICANN)
+This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers [(ICANN)](https://www.icann.org).
 for use with the Registry Data Access Protocol (RDAP). RDAP is standard of the [IETF](https://ietf.org/), and extensions
 to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
-
-***THIS PROJECT IS IN ALPHA STAGE.*** You are welcome to use it and file issues or bug reports, however there are no
-guarantees as to timeliness of responses.
+More information on ICANN's role in RDAP can be found [here](https://www.icann.org/rdap).
 
 About
 -----

--- a/icann-rdap-cli/Cargo.toml
+++ b/icann-rdap-cli/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/main.rs"
 
 [dependencies]
 
-icann-rdap-client = { version = "0.0.11", path = "../icann-rdap-client" }
-icann-rdap-common = { version = "0.0.11", path = "../icann-rdap-common" }
+icann-rdap-client = { version = "0.0.12", path = "../icann-rdap-client" }
+icann-rdap-common = { version = "0.0.12", path = "../icann-rdap-common" }
 
 anyhow.workspace = true
 clap.workspace = true

--- a/icann-rdap-cli/Cargo.toml
+++ b/icann-rdap-cli/Cargo.toml
@@ -32,10 +32,11 @@ prefix-trie.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-simplelog.workspace = true
 termimad.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 [dev-dependencies]
 

--- a/icann-rdap-cli/README.md
+++ b/icann-rdap-cli/README.md
@@ -1,12 +1,11 @@
-ICANN RDAP
-==========
+ICANN RDAP CLI
+==============
 
-This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers (ICANN)
-for use with the Registry Data Access Protocol (RDAP). RDAP is standard of the [IETF](https://ietf.org/), and extensions
+This is a command-line interface (CLI) client for the Registration Data Access Protocol (RDAP) written and sponsored
+by the Internet Corporation for Assigned Names and Numbers [(ICANN)](https://www.icann.org). 
+RDAP is standard of the [IETF](https://ietf.org/), and extensions
 to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
-
-***THIS PROJECT IS IN ALPHA STAGE.*** You are welcome to use it and file issues or bug reports, however there are no
-guarantees as to timeliness of responses.
+More information on ICANN's role in RDAP can be found [here](https://www.icann.org/rdap).
 
 Installing the RDAP Client
 --------------------------

--- a/icann-rdap-cli/src/after_long_help.txt
+++ b/icann-rdap-cli/src/after_long_help.txt
@@ -8,7 +8,20 @@ On Linux, this file is located at $XDG_CONFIG_HOME/rdap/rdap.env or
 $HOME/.config/rdap/rdap.env.
 
 On macOS, this file is located at 
-$HOME/Library/Application Support/rdap/rdap.env.
+$HOME/Library/Application Support/org.ICANN.rdap/rdap.env.
 
 On Windows, this file is located at
 {FOLDERID_RoamingAppData}\rdap\config\rdap.env.
+
+Caches:
+
+Cache data used by this program is kept in a location dependent on the platform:
+
+On Linux, these files are located at $XDG_CACHE_HOME/rdap/ or 
+$HOME/.cache/rdap/.
+
+On macOS, these files are located at 
+$HOME/Library/Caches/org.ICANN.rdap/.
+
+On Windows, this file is located at
+{FOLDERID_LocalAppData}\rdap\.

--- a/icann-rdap-cli/src/bootstrap.rs
+++ b/icann-rdap-cli/src/bootstrap.rs
@@ -12,7 +12,7 @@ use icann_rdap_common::{
 use ipnet::{Ipv4Net, Ipv6Net};
 use prefix_trie::PrefixMap;
 use reqwest::Client;
-use simplelog::debug;
+use tracing::debug;
 
 use crate::{dirs::bootstrap_cache_path, error::CliError};
 

--- a/icann-rdap-cli/src/main.rs
+++ b/icann-rdap-cli/src/main.rs
@@ -435,6 +435,11 @@ pub async fn main() -> anyhow::Result<()> {
             res1.0?;
         } else {
             let pager = minus::Pager::new();
+            pager
+                .set_prompt(format!(
+                    "{query_type} - Q to quit, j/k or pgup/pgdn to scroll"
+                ))
+                .expect("unable to set prompt");
             let output = FmtWrite(pager.clone());
             let pager2 = pager.clone();
 

--- a/icann-rdap-cli/src/query.rs
+++ b/icann-rdap-cli/src/query.rs
@@ -2,8 +2,6 @@ use icann_rdap_common::check::traverse_checks;
 use icann_rdap_common::check::CheckClass;
 use icann_rdap_common::check::CheckParams;
 use icann_rdap_common::check::GetChecks;
-use minus::Pager;
-use std::io::ErrorKind;
 use tracing::error;
 use tracing::info;
 
@@ -305,38 +303,6 @@ fn do_final_output<W: std::io::Write>(
     }
 
     Ok(())
-}
-
-#[derive(Clone)]
-pub(crate) struct BridgeWriter<W: std::fmt::Write>(pub(crate) W);
-
-impl<W: std::fmt::Write> std::io::Write for BridgeWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0
-            .write_str(&String::from_utf8_lossy(buf))
-            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct PageWriter(pub(crate) Pager);
-
-impl std::io::Write for PageWriter {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.0
-            .push_str(String::from_utf8_lossy(buf))
-            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
-    }
 }
 
 fn get_related_link(rdap_response: &RdapResponse) -> Vec<&str> {

--- a/icann-rdap-cli/src/request.rs
+++ b/icann-rdap-cli/src/request.rs
@@ -11,7 +11,7 @@ use icann_rdap_common::cache::HttpData;
 use pct_str::PctString;
 use pct_str::URIReserved;
 use reqwest::Client;
-use simplelog::{debug, info};
+use tracing::{info, log::debug};
 
 use crate::{dirs::rdap_cache_path, error::CliError, query::ProcessingParams};
 

--- a/icann-rdap-cli/src/write.rs
+++ b/icann-rdap-cli/src/write.rs
@@ -1,0 +1,35 @@
+use std::io::ErrorKind;
+
+use minus::Pager;
+
+#[derive(Clone)]
+pub(crate) struct FmtWrite<W: std::fmt::Write>(pub(crate) W);
+
+impl<W: std::fmt::Write> std::io::Write for FmtWrite<W> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .write_str(&String::from_utf8_lossy(buf))
+            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct PagerWrite(pub(crate) Pager);
+
+impl std::io::Write for PagerWrite {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .push_str(String::from_utf8_lossy(buf))
+            .map_err(|e| std::io::Error::new(ErrorKind::Other, e))?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/icann-rdap-cli/tests/integration/cache.rs
+++ b/icann-rdap-cli/tests/integration/cache.rs
@@ -39,4 +39,10 @@ async fn GIVEN_domain_with_entity_WHEN_retreived_from_cache_THEN_is_domain() {
     let rdap = &responses.first().expect("response is empty").res_data.rdap;
     println!("response type is {rdap}");
     assert!(matches!(rdap, RdapResponse::Domain(_)));
+    let rdap_type = &responses
+        .first()
+        .expect("response is empty")
+        .res_data
+        .rdap_type;
+    assert_eq!(rdap_type, "Domain");
 }

--- a/icann-rdap-cli/tests/integration/cache.rs
+++ b/icann-rdap-cli/tests/integration/cache.rs
@@ -1,0 +1,42 @@
+#![allow(non_snake_case)]
+
+use icann_rdap_client::request::RequestResponseOwned;
+use icann_rdap_common::response::{domain::Domain, entity::Entity, RdapResponse};
+use icann_rdap_srv::storage::StoreOps;
+
+use crate::test_jig::TestJig;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn GIVEN_domain_with_entity_WHEN_retreived_from_cache_THEN_is_domain() {
+    // GIVEN
+    let mut test_jig = TestJig::new();
+    let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
+    tx.add_domain(
+        &Domain::basic()
+            .ldh_name("foo.example")
+            .entities(vec![Entity::basic().handle("bob").build()])
+            .build(),
+    )
+    .await
+    .expect("add domain in tx");
+    tx.commit().await.expect("tx commit");
+
+    test_jig.cmd.arg("foo.example");
+    let output = test_jig.cmd.output().expect("executing domain query");
+    let responses: Vec<RequestResponseOwned> =
+        serde_json::from_slice(&output.stdout).expect("parsing stdout");
+    let rdap = &responses.first().expect("response is empty").res_data.rdap;
+    println!("response type is {rdap}");
+
+    // WHEN
+    let mut test_jig = test_jig.new_cmd();
+    test_jig.cmd.arg("foo.example");
+
+    // THEN
+    let output = test_jig.cmd.output().expect("executing domain query");
+    let responses: Vec<RequestResponseOwned> =
+        serde_json::from_slice(&output.stdout).expect("parsing stdout");
+    let rdap = &responses.first().expect("response is empty").res_data.rdap;
+    println!("response type is {rdap}");
+    assert!(matches!(rdap, RdapResponse::Domain(_)));
+}

--- a/icann-rdap-cli/tests/integration/cache.rs
+++ b/icann-rdap-cli/tests/integration/cache.rs
@@ -14,7 +14,7 @@ async fn GIVEN_domain_with_entity_WHEN_retreived_from_cache_THEN_is_domain() {
     tx.add_domain(
         &Domain::basic()
             .ldh_name("foo.example")
-            .entities(vec![Entity::basic().handle("bob").build()])
+            .entity(Entity::basic().handle("bob").build())
             .build(),
     )
     .await

--- a/icann-rdap-cli/tests/integration/main.rs
+++ b/icann-rdap-cli/tests/integration/main.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod check;
 mod queries;
 mod source;

--- a/icann-rdap-cli/tests/integration/queries.rs
+++ b/icann-rdap-cli/tests/integration/queries.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use cidr_utils::cidr::IpCidr;
 use icann_rdap_common::response::{
     autnum::Autnum, domain::Domain, entity::Entity, nameserver::Nameserver, network::Network,
 };
@@ -54,9 +53,14 @@ async fn GIVEN_nameserver_WHEN_query_THEN_success() {
     // GIVEN
     let mut test_jig = TestJig::new();
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
-    tx.add_nameserver(&Nameserver::basic().ldh_name("ns.foo.example").build())
-        .await
-        .expect("add nameserver in tx");
+    tx.add_nameserver(
+        &Nameserver::basic()
+            .ldh_name("ns.foo.example")
+            .build()
+            .unwrap(),
+    )
+    .await
+    .expect("add nameserver in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -72,14 +76,9 @@ async fn GIVEN_autnum_WHEN_query_THEN_success() {
     // GIVEN
     let mut test_jig = TestJig::new();
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
-    tx.add_autnum(
-        &Autnum::basic_nums()
-            .start_autnum(700)
-            .end_autnum(710)
-            .build(),
-    )
-    .await
-    .expect("add autnum in tx");
+    tx.add_autnum(&Autnum::basic().autnum_range(700..710).build())
+        .await
+        .expect("add autnum in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -97,8 +96,9 @@ async fn GIVEN_network_ip_WHEN_query_THEN_success() {
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
     tx.add_network(
         &Network::basic()
-            .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-            .build(),
+            .cidr("10.0.0.0/24")
+            .build()
+            .expect("cidr parsing"),
     )
     .await
     .expect("add network in tx");
@@ -122,8 +122,9 @@ async fn GIVEN_network_cidr_WHEN_query_THEN_success(#[case] db_cidr: &str, #[cas
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
     tx.add_network(
         &Network::basic()
-            .cidr(IpCidr::from_str(db_cidr).expect("cidr parsing"))
-            .build(),
+            .cidr(db_cidr)
+            .build()
+            .expect("cidr parsing"),
     )
     .await
     .expect("add network in tx");

--- a/icann-rdap-cli/tests/integration/source.rs
+++ b/icann-rdap-cli/tests/integration/source.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use cidr_utils::cidr::IpCidr;
 use icann_rdap_client::request::{RequestResponseOwned, SourceType};
 use icann_rdap_common::response::network::Network;
 use icann_rdap_srv::storage::StoreOps;
@@ -21,8 +20,9 @@ async fn GIVEN_inr_query_WHEN_query_THEN_source_is_rir(
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
     tx.add_network(
         &Network::basic()
-            .cidr(IpCidr::from_str(db_cidr).expect("cidr parsing"))
-            .build(),
+            .cidr(db_cidr)
+            .build()
+            .expect("cidr parsing"),
     )
     .await
     .expect("add network in tx");

--- a/icann-rdap-cli/tests/integration/test_jig.rs
+++ b/icann-rdap-cli/tests/integration/test_jig.rs
@@ -51,4 +51,18 @@ impl TestJig {
             _test_dir: test_dir,
         }
     }
+
+    pub fn new_cmd(self) -> TestJig {
+        let mut cmd = Command::cargo_bin("rdap").expect("cannot find rdap cmd");
+        cmd.env_clear()
+            .timeout(Duration::from_secs(2))
+            .env("RDAP_BASE_URL", self.rdap_base.clone())
+            .env("RDAP_PAGING", "none")
+            .env("RDAP_OUTPUT", "json-extra")
+            .env("RDAP_LOG", "debug")
+            .env("RDAP_ALLOW_HTTP", "true")
+            .env("XDG_CACHE_HOME", self._test_dir.path("cache"))
+            .env("XDG_CONFIG_HOME", self._test_dir.path("config"));
+        TestJig { cmd, ..self }
+    }
 }

--- a/icann-rdap-cli/tests/integration/url.rs
+++ b/icann-rdap-cli/tests/integration/url.rs
@@ -1,7 +1,5 @@
 #![allow(non_snake_case)]
 
-use cidr_utils::cidr::IpCidr;
-
 use icann_rdap_common::response::network::Network;
 use icann_rdap_srv::storage::StoreOps;
 
@@ -14,8 +12,9 @@ async fn GIVEN_url_used_with_base_url_WHEN_query_THEN_success() {
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
     tx.add_network(
         &Network::basic()
-            .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-            .build(),
+            .cidr("10.0.0.0/24")
+            .build()
+            .expect("cidr parsing"),
     )
     .await
     .expect("add network in tx");
@@ -38,8 +37,9 @@ async fn GIVEN_url_used_with_no_base_url_WHEN_query_THEN_success() {
     let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
     tx.add_network(
         &Network::basic()
-            .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-            .build(),
+            .cidr("10.0.0.0/24")
+            .build()
+            .expect("cidr parsing"),
     )
     .await
     .expect("add network in tx");

--- a/icann-rdap-client/Cargo.toml
+++ b/icann-rdap-client/Cargo.toml
@@ -10,7 +10,7 @@ An RDAP client library.
 
 [dependencies]
 
-icann-rdap-common = { version = "0.0.11", path = "../icann-rdap-common" }
+icann-rdap-common = { version = "0.0.12", path = "../icann-rdap-common" }
 
 buildstructor.workspace = true
 cidr-utils.workspace = true

--- a/icann-rdap-client/README.md
+++ b/icann-rdap-client/README.md
@@ -1,13 +1,11 @@
-ICANN RDAP
-==========
+ICANN RDAP Client Library
+=========================
 
-This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers (ICANN)
-for use with the Registry Data Access Protocol (RDAP). RDAP is standard of the [IETF](https://ietf.org/), and extensions
+This is a client library for the Registration Data Access Protocol (RDAP) written and sponsored
+by the Internet Corporation for Assigned Names and Numbers [(ICANN)](https://www.icann.org). 
+RDAP is standard of the [IETF](https://ietf.org/), and extensions
 to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
-
-***THIS PROJECT IS IN ALPHA STAGE.*** You are welcome to use it and file issues or bug reports, however there are no
-guarantees as to timeliness of responses.
-
+More information on ICANN's role in RDAP can be found [here](https://www.icann.org/rdap).
 
 Installation
 ------------

--- a/icann-rdap-client/src/lib.rs
+++ b/icann-rdap-client/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)] // TODO remove this at some point
+#![allow(rustdoc::bare_urls)]
 #![doc = include_str!("../README.md")]
 use std::fmt::Display;
 

--- a/icann-rdap-client/src/md/network.rs
+++ b/icann-rdap-client/src/md/network.rs
@@ -43,6 +43,7 @@ impl ToMd for Network {
             .and_data_ref(&"Start Address", &self.start_address)
             .and_data_ref(&"End Address", &self.end_address)
             .and_data_ref(&"IP Version", &self.ip_version)
+            .and_data_ul(&"CIDR", self.cidr0_cidrs.clone())
             .and_data_ref(&"Handle", &self.object_common.handle)
             .and_data_ref(&"Parent Handle", &self.parent_handle)
             .and_data_ref(&"Network Type", &self.network_type)

--- a/icann-rdap-client/src/query/request.rs
+++ b/icann-rdap-client/src/query/request.rs
@@ -46,7 +46,11 @@ pub async fn rdap_request(
             .and_expires(expires)
             .and_cache_control(cache_control)
             .build();
-        Ok(ResponseData { rdap, http_data })
+        Ok(ResponseData {
+            http_data,
+            rdap_type: rdap.to_string(),
+            rdap,
+        })
     } else {
         Err(RdapClientError::ParsingError(Box::new(
             crate::ParsingErrorInfo {
@@ -63,5 +67,6 @@ pub async fn rdap_request(
 #[derive(Serialize, Deserialize, Clone)]
 pub struct ResponseData {
     pub rdap: RdapResponse,
+    pub rdap_type: String,
     pub http_data: HttpData,
 }

--- a/icann-rdap-common/README.md
+++ b/icann-rdap-common/README.md
@@ -1,12 +1,12 @@
-ICANN RDAP
-==========
+ICANN RDAP Common
+=================
 
-This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers (ICANN)
-for use with the Registry Data Access Protocol (RDAP). RDAP is standard of the [IETF](https://ietf.org/), and extensions
+This is a common component library for the Registration Data Access Protocol (RDAP) written and sponsored
+by the Internet Corporation for Assigned Names and Numbers [(ICANN)](https://www.icann.org). 
+RDAP is standard of the [IETF](https://ietf.org/), and extensions
 to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
+More information on ICANN's role in RDAP can be found [here](https://www.icann.org/rdap).
 
-***THIS PROJECT IS IN ALPHA STAGE.*** You are welcome to use it and file issues or bug reports, however there are no
-guarantees as to timeliness of responses.
 
 Installation
 ------------

--- a/icann-rdap-common/README.md
+++ b/icann-rdap-common/README.md
@@ -21,27 +21,25 @@ Usage
 Create some RDAP objects:
 
 ```rust
+// create an entity
+use icann_rdap_common::response::entity::Entity;
+let holder = Entity::basic().handle("foo-BAR").build();
+
 // create an RDAP domain
 use icann_rdap_common::response::domain::Domain;
-let domain = Domain::basic().ldh_name("example.com").build();
+let domain = Domain::basic().ldh_name("example.com").entity(holder.clone()).build();
 
 // create an IP network
-use cidr_utils::cidr::IpCidr;
-let cidr = IpCidr::from_str("10.0.0.0/16").unwrap();
 use icann_rdap_common::response::network::Network;
-let net = Network::basic().cidr(cidr).build();
+let net = Network::basic().cidr("10.0.0.0/16").entity(holder.clone()).build().unwrap();
 
 // create a nameserver
 use icann_rdap_common::response::nameserver::Nameserver;
-let ns = Nameserver::basic().ldh_name("ns1.example.com").build();
+let ns = Nameserver::basic().ldh_name("ns1.example.com").entity(holder.clone()).build().unwrap();
 
 // create an autnum
 use icann_rdap_common::response::autnum::Autnum;
-let autnum = Autnum::basic().autnum(700).build();
-
-// create an entity
-use icann_rdap_common::response::entity::Entity;
-let entity = Entity::basic().handle("foo-BAR").build();
+let autnum = Autnum::basic().autnum_range(700..700).entity(holder).build();
 ```
 
 Parse RDAP JSON:

--- a/icann-rdap-common/README.md
+++ b/icann-rdap-common/README.md
@@ -18,6 +18,8 @@ This library can be compiled for WASM targets.
 Usage
 -----
 
+Create some RDAP objects:
+
 ```rust
 // create an RDAP domain
 use icann_rdap_common::response::domain::Domain;
@@ -40,6 +42,42 @@ let autnum = Autnum::basic().autnum(700).build();
 // create an entity
 use icann_rdap_common::response::entity::Entity;
 let entity = Entity::basic().handle("foo-BAR").build();
+```
+
+Parse RDAP JSON:
+
+```rust
+use icann_rdap_common::response::RdapResponse;
+
+let json = r#"
+  {
+    "objectClassName": "ip network",
+    "links": [
+      {
+        "value": "http://localhost:3000/rdap/ip/10.0.0.0/16",
+        "rel": "self",
+        "href": "http://localhost:3000/rdap/ip/10.0.0.0/16",
+        "type": "application/rdap+json"
+      }
+    ],
+    "events": [
+      {
+        "eventAction": "registration",
+        "eventDate": "2023-06-16T22:56:49.594173356+00:00"
+      },
+      {
+        "eventAction": "last changed",
+        "eventDate": "2023-06-16T22:56:49.594189140+00:00"
+      }
+    ],
+    "startAddress": "10.0.0.0",
+    "endAddress": "10.0.255.255",
+    "ipVersion": "v4"
+  }
+"#;
+
+let rdap: RdapResponse = serde_json::from_str(json).unwrap();
+assert!(matches!(rdap, RdapResponse::Network(_)));
 ```
 
 License

--- a/icann-rdap-common/src/check/autnum.rs
+++ b/icann-rdap-common/src/check/autnum.rs
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn GIVEN_autnum_with_empty_name_WHEN_checked_THEN_empty_name_check() {
         // GIVEN
-        let mut autnum = Autnum::new_autnum(700);
+        let mut autnum = Autnum::basic().autnum_range(700..700).build();
         autnum.name = Some("".to_string());
         let rdap = RdapResponse::Autnum(autnum);
 
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     fn GIVEN_autnum_with_empty_type_WHEN_checked_THEN_empty_type_check() {
         // GIVEN
-        let mut autnum = Autnum::new_autnum(700);
+        let mut autnum = Autnum::basic().autnum_range(700..700).build();
         autnum.autnum_type = Some("".to_string());
         let rdap = RdapResponse::Autnum(autnum);
 

--- a/icann-rdap-common/src/check/domain.rs
+++ b/icann-rdap-common/src/check/domain.rs
@@ -76,7 +76,7 @@ mod tests {
     #[case("_.")]
     fn GIVEN_domain_with_bad_ldh_WHEN_checked_THEN_invalid_ldh(#[case] ldh: &str) {
         // GIVEN
-        let domain = Domain::new_ldh(ldh, None);
+        let domain = Domain::basic().ldh_name(ldh).build();
         let rdap = RdapResponse::Domain(domain);
 
         // WHEN

--- a/icann-rdap-common/src/check/domain.rs
+++ b/icann-rdap-common/src/check/domain.rs
@@ -76,7 +76,7 @@ mod tests {
     #[case("_.")]
     fn GIVEN_domain_with_bad_ldh_WHEN_checked_THEN_invalid_ldh(#[case] ldh: &str) {
         // GIVEN
-        let domain = Domain::new_ldh(ldh);
+        let domain = Domain::new_ldh(ldh, None);
         let rdap = RdapResponse::Domain(domain);
 
         // WHEN

--- a/icann-rdap-common/src/check/nameserver.rs
+++ b/icann-rdap-common/src/check/nameserver.rs
@@ -77,7 +77,7 @@ mod tests {
     #[case("_.")]
     fn GIVEN_nameserver_with_bad_ldh_WHEN_checked_THEN_invalid_ldh(#[case] ldh: &str) {
         // GIVEN
-        let ns = Nameserver::new_ldh(ldh);
+        let ns = Nameserver::basic().ldh_name(ldh).build().unwrap();
         let rdap = RdapResponse::Nameserver(ns);
 
         // WHEN

--- a/icann-rdap-common/src/check/network.rs
+++ b/icann-rdap-common/src/check/network.rs
@@ -138,7 +138,7 @@ impl GetChecks for Network {
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
-    use cidr_utils::cidr::IpCidr;
+
     use rstest::rstest;
 
     use crate::response::network::Network;
@@ -149,8 +149,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_empty_name_WHEN_checked_THEN_empty_name_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.name = Some("".to_string());
         let rdap = RdapResponse::Network(network);
 
@@ -169,8 +171,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_empty_type_WHEN_checked_THEN_empty_type_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.network_type = Some("".to_string());
         let rdap = RdapResponse::Network(network);
 
@@ -189,8 +193,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_no_start_WHEN_checked_THEN_missing_ip_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.start_address = None;
         let rdap = RdapResponse::Network(network);
 
@@ -212,8 +218,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_no_end_WHEN_checked_THEN_missing_ip_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.end_address = None;
         let rdap = RdapResponse::Network(network);
 
@@ -235,8 +243,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_bad_start_WHEN_checked_THEN_malformed_ip_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.start_address = Some("____".to_string());
         let rdap = RdapResponse::Network(network);
 
@@ -258,8 +268,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_bad_end_WHEN_checked_THEN_malformed_ip_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         network.end_address = Some("___".to_string());
         let rdap = RdapResponse::Network(network);
 
@@ -281,8 +293,10 @@ mod tests {
     #[test]
     fn GIVEN_network_with_end_before_start_WHEN_checked_THEN_end_before_start_check() {
         // GIVEN
-        let mut network =
-            Network::new_network(IpCidr::from_str("10.0.0.0/8").expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr("10.0.0.0/8")
+            .build()
+            .expect("invalid ip cidr");
         let swap = network.end_address.clone();
         network.end_address = network.start_address.clone();
         network.start_address = swap;
@@ -311,7 +325,10 @@ mod tests {
         #[case] version: &str,
     ) {
         // GIVEN
-        let mut network = Network::new_network(IpCidr::from_str(cidr).expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr(cidr)
+            .build()
+            .expect("invalid ip cidr");
         network.ip_version = Some(version.to_string());
         let rdap = RdapResponse::Network(network);
 
@@ -340,7 +357,10 @@ mod tests {
         #[case] version: &str,
     ) {
         // GIVEN
-        let mut network = Network::new_network(IpCidr::from_str(cidr).expect("invalid ip cidr"));
+        let mut network = Network::basic()
+            .cidr(cidr)
+            .build()
+            .expect("invalid ip cidr");
         network.ip_version = Some(version.to_string());
         let rdap = RdapResponse::Network(network);
 

--- a/icann-rdap-common/src/check/string.rs
+++ b/icann-rdap-common/src/check/string.rs
@@ -5,7 +5,7 @@ pub trait StringCheck {
     /// Tests if the string contains only letters, digits, or hyphens and is not empty.
     fn is_ldh_string(&self) -> bool;
 
-    /// Tests if a string is an LDH doamin name. This is not to be confused with [is_ldh_string],
+    /// Tests if a string is an LDH doamin name. This is not to be confused with [StringCheck::is_ldh_string],
     /// which checks individual domain labels.
     fn is_ldh_domain_name(&self) -> bool;
 }

--- a/icann-rdap-common/src/check/types.rs
+++ b/icann-rdap-common/src/check/types.rs
@@ -613,7 +613,10 @@ mod tests {
         #[case] status: Vec<StatusValue>,
     ) {
         // GIVEN
-        let mut ns = Nameserver::new_ldh("ns1.example.com");
+        let mut ns = Nameserver::basic()
+            .ldh_name("ns1.example.com")
+            .build()
+            .unwrap();
         ns.object_common.status = Some(status);
         let rdap = RdapResponse::Nameserver(ns);
 
@@ -639,7 +642,10 @@ mod tests {
     #[test]
     fn GIVEN_nameserver_with_empty_handle_WHEN_checked_THEN_handle_is_empty(#[case] handle: &str) {
         // GIVEN
-        let mut ns = Nameserver::new_ldh("ns1.example.com");
+        let mut ns = Nameserver::basic()
+            .ldh_name("ns1.example.com")
+            .build()
+            .unwrap();
         ns.object_common.handle = Some(handle.to_string());
         let rdap = RdapResponse::Nameserver(ns);
 

--- a/icann-rdap-common/src/contact/mod.rs
+++ b/icann-rdap-common/src/contact/mod.rs
@@ -7,6 +7,16 @@ use buildstructor::Builder;
 
 /// Represents a contact. This more closely represents an EPP Contact with some
 /// things taken from JSContact.
+///
+/// Using the builder to create the Contact:
+/// ```rust
+/// use icann_rdap_common::contact::Contact;
+///
+/// let contact = Contact::builder()
+///   .kind("individual")
+///   .full_name("Bob Smurd")
+///   .build();
+/// ```
 #[derive(Debug, Builder, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Contact {
     /// Preferred languages.

--- a/icann-rdap-common/src/lib.rs
+++ b/icann-rdap-common/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(rustdoc::bare_urls)]
 #![doc = include_str!("../README.md")]
 pub mod cache;
 pub mod check;

--- a/icann-rdap-common/src/response/domain.rs
+++ b/icann-rdap-common/src/response/domain.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     nameserver::Nameserver,
     network::Network,
-    types::{Common, Events, Links, ObjectCommon, PublicIds},
+    types::{to_option_status, Common, Events, Links, ObjectCommon, PublicIds},
 };
 
 /// Represents an RDAP variant name.
@@ -139,19 +139,50 @@ pub struct Domain {
 
 #[buildstructor::buildstructor]
 impl Domain {
+    /// Builds a basic domain object.
+    ///
+    /// ```rust
+    /// use icann_rdap_common::response::domain::Domain;
+    /// use icann_rdap_common::response::types::StatusValue;
+    ///
+    /// let domain = Domain::basic()
+    ///   .ldh_name("foo.example.com")
+    ///   .handle("foo_example_com-1")
+    ///   .status("active")
+    ///   .build();
+    /// ```
     #[builder(entry = "basic")]
     pub fn new_ldh<T: Into<String>>(
         ldh_name: T,
-        entities: Option<Vec<crate::response::entity::Entity>>,
+        nameservers: Option<Vec<Nameserver>>,
+        handle: Option<String>,
+        remarks: Vec<crate::response::types::Remark>,
+        links: Vec<crate::response::types::Link>,
+        events: Vec<crate::response::types::Event>,
+        statuses: Vec<String>,
+        port_43: Option<crate::response::types::Port43>,
+        entities: Vec<crate::response::entity::Entity>,
     ) -> Self {
+        let entities = (!entities.is_empty()).then_some(entities);
+        let remarks = (!remarks.is_empty()).then_some(remarks);
+        let links = (!links.is_empty()).then_some(links);
+        let events = (!events.is_empty()).then_some(events);
         Self {
             common: Common::builder().build(),
-            object_common: ObjectCommon::domain().and_entities(entities).build(),
+            object_common: ObjectCommon::domain()
+                .and_handle(handle)
+                .and_remarks(remarks)
+                .and_links(links)
+                .and_events(events)
+                .and_status(to_option_status(statuses))
+                .and_port_43(port_43)
+                .and_entities(entities)
+                .build(),
             ldh_name: Some(ldh_name.into()),
             unicode_name: None,
             variants: None,
             secure_dns: None,
-            nameservers: None,
+            nameservers,
             public_ids: None,
             network: None,
         }

--- a/icann-rdap-common/src/response/domain.rs
+++ b/icann-rdap-common/src/response/domain.rs
@@ -140,10 +140,13 @@ pub struct Domain {
 #[buildstructor::buildstructor]
 impl Domain {
     #[builder(entry = "basic")]
-    pub fn new_ldh<T: Into<String>>(ldh_name: T) -> Self {
+    pub fn new_ldh<T: Into<String>>(
+        ldh_name: T,
+        entities: Option<Vec<crate::response::entity::Entity>>,
+    ) -> Self {
         Self {
             common: Common::builder().build(),
-            object_common: ObjectCommon::domain().build(),
+            object_common: ObjectCommon::domain().and_entities(entities).build(),
             ldh_name: Some(ldh_name.into()),
             unicode_name: None,
             variants: None,

--- a/icann-rdap-common/src/response/mod.rs
+++ b/icann-rdap-common/src/response/mod.rs
@@ -2,6 +2,7 @@ use std::any::TypeId;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use strum_macros::Display;
 use thiserror::Error;
 
 use self::{
@@ -37,8 +38,8 @@ pub enum RdapResponseError {
 }
 
 /// The various types of RDAP response.
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(untagged)]
+#[derive(Serialize, Deserialize, Clone, Display)]
+#[serde(untagged, try_from = "Value")]
 pub enum RdapResponse {
     // Object Classes
     Entity(Entity),
@@ -335,5 +336,19 @@ mod tests {
 
         // THEN
         assert!(matches!(actual, RdapResponse::ErrorResponse(_)));
+    }
+
+    #[test]
+    fn GIVEN_entity_search_results_variant_WHEN_to_string_THEN_string_is_entity() {
+        // GIVEN
+        let entity: Value =
+            serde_json::from_str(include_str!("test_files/entities_fn_arin.json")).unwrap();
+        let value = RdapResponse::try_from(entity).unwrap();
+
+        // WHEN
+        let actual = value.to_string();
+
+        // THEN
+        assert_eq!(actual, "EntitySearchResults");
     }
 }

--- a/icann-rdap-common/src/response/mod.rs
+++ b/icann-rdap-common/src/response/mod.rs
@@ -35,9 +35,49 @@ pub enum RdapResponseError {
     UnknownRdapResponse,
     #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
+    #[error(transparent)]
+    AddrParse(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    CidrParse(#[from] cidr_utils::cidr::IpCidrError),
 }
 
 /// The various types of RDAP response.
+///
+/// It can be parsed from JSON using serde:
+///
+/// ```rust
+/// use icann_rdap_common::response::RdapResponse;
+///
+/// let json = r#"
+///   {
+///     "objectClassName": "ip network",
+///     "links": [
+///       {
+///         "value": "http://localhost:3000/rdap/ip/10.0.0.0/16",
+///         "rel": "self",
+///         "href": "http://localhost:3000/rdap/ip/10.0.0.0/16",
+///         "type": "application/rdap+json"
+///       }
+///     ],
+///     "events": [
+///       {
+///         "eventAction": "registration",
+///         "eventDate": "2023-06-16T22:56:49.594173356+00:00"
+///       },
+///       {
+///         "eventAction": "last changed",
+///         "eventDate": "2023-06-16T22:56:49.594189140+00:00"
+///       }
+///     ],
+///     "startAddress": "10.0.0.0",
+///     "endAddress": "10.0.255.255",
+///     "ipVersion": "v4"
+///   }
+/// "#;
+///
+/// let rdap: RdapResponse = serde_json::from_str(json).unwrap();
+/// assert!(matches!(rdap, RdapResponse::Network(_)));
+/// ```
 #[derive(Serialize, Deserialize, Clone, Display)]
 #[serde(untagged, try_from = "Value")]
 pub enum RdapResponse {

--- a/icann-rdap-common/src/response/network.rs
+++ b/icann-rdap-common/src/response/network.rs
@@ -7,6 +7,46 @@ use super::{
     RdapResponseError,
 };
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum Cidr0Cidr {
+    V4Cidr(V4Cidr),
+    V6Cidr(V6Cidr),
+}
+
+impl std::fmt::Display for Cidr0Cidr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Cidr0Cidr::V4Cidr(cidr) => cidr.fmt(f),
+            Cidr0Cidr::V6Cidr(cidr) => cidr.fmt(f),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Builder, Clone, Debug, PartialEq, Eq)]
+pub struct V4Cidr {
+    pub v4prefix: String,
+    pub length: u8,
+}
+
+impl std::fmt::Display for V4Cidr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.v4prefix, self.length)
+    }
+}
+
+#[derive(Serialize, Deserialize, Builder, Clone, Debug, PartialEq, Eq)]
+pub struct V6Cidr {
+    pub v6prefix: String,
+    pub length: u8,
+}
+
+impl std::fmt::Display for V6Cidr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.v6prefix, self.length)
+    }
+}
+
 /// Represents an RDAP network response.
 #[derive(Serialize, Deserialize, Builder, Clone, Debug, PartialEq, Eq)]
 pub struct Network {
@@ -41,6 +81,9 @@ pub struct Network {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub country: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cidr0_cidrs: Option<Vec<Cidr0Cidr>>,
 }
 
 #[buildstructor::buildstructor]
@@ -94,6 +137,7 @@ impl Network {
             network_type: None,
             parent_handle: None,
             country: None,
+            cidr0_cidrs: None,
         })
     }
 }

--- a/icann-rdap-common/src/response/types.rs
+++ b/icann-rdap-common/src/response/types.rs
@@ -7,6 +7,12 @@ use super::entity::Entity;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct Extension(pub String);
 
+impl From<&str> for Extension {
+    fn from(value: &str) -> Self {
+        Extension(value.to_string())
+    }
+}
+
 /// The RDAP conformance array.
 pub type RdapConformance = Vec<Extension>;
 
@@ -96,8 +102,27 @@ pub struct Event {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct StatusValue(pub String);
 
+impl From<&str> for StatusValue {
+    fn from(value: &str) -> Self {
+        StatusValue(value.to_string())
+    }
+}
+
 /// An array of status values.
 pub type Status = Vec<StatusValue>;
+
+pub fn to_option_status(values: Vec<String>) -> Option<Status> {
+    if !values.is_empty() {
+        Some(
+            values
+                .into_iter()
+                .map(|s| StatusValue::from(s.as_str()))
+                .collect::<Status>(),
+        )
+    } else {
+        None
+    }
+}
 
 /// An RDAP port53 type.
 pub type Port43 = String;

--- a/icann-rdap-srv/Cargo.toml
+++ b/icann-rdap-srv/Cargo.toml
@@ -10,8 +10,8 @@ An RDAP Server.
 
 [dependencies]
 
-icann-rdap-client = { version = "0.0.11", path = "../icann-rdap-client" }
-icann-rdap-common = { version = "0.0.11", path = "../icann-rdap-common" }
+icann-rdap-client = { version = "0.0.12", path = "../icann-rdap-client" }
+icann-rdap-common = { version = "0.0.12", path = "../icann-rdap-common" }
 
 async-trait.workspace = true
 axum.workspace = true

--- a/icann-rdap-srv/README.md
+++ b/icann-rdap-srv/README.md
@@ -1,18 +1,18 @@
 ICANN RDAP Server
 =================
-This repository contains open source code written by the Internet Corporation for Assigned Names and Numbers (ICANN)
-for use with the Registry Data Access Protocol (RDAP). RDAP is standard of the [IETF](https://ietf.org/), and extensions
-to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
-
-***THIS PROJECT IS IN ALPHA STAGE.*** You are welcome to use it and file issues or bug reports, however there are no
-guarantees as to timeliness of responses.
 
 This server was created to aid in the development of the ICANN RDAP Command Line Interface client.
 It can be used as a library or as a server started within its own process. It currently has in-memory
 storage, though its storage layer is architected to accomodate a PostgreSQL backend if that is needed
 in the future.
 
-RDAP core support is as follows:
+This software is written and sponsored
+by the Internet Corporation for Assigned Names and Numbers [(ICANN)](https://www.icann.org). 
+RDAP is standard of the [IETF](https://ietf.org/), and extensions
+to RDAP are a current work activity of the IETF's [REGEXT working group](https://datatracker.ietf.org/wg/regext/documents/).
+More information on ICANN's role in RDAP can be found [here](https://www.icann.org/rdap).
+
+RDAP core support in this server is as follows:
 
 - [X] LDH Domain lookup (`/domain/ldh`)
 - [X] Entity lookup (`/entity/handle`)

--- a/icann-rdap-srv/src/bin/rdap-srv-data.rs
+++ b/icann-rdap-srv/src/bin/rdap-srv-data.rs
@@ -98,15 +98,15 @@ struct ObjectArgs {
 
     /// Adds a server notice.
     ///
-    /// Takes the form of "[LINK] description" where the optional [LINK] takes
-    /// the form of "(REL;TYPE)[HREF]". This argument maybe specified multiple times.
+    /// Takes the form of "\[LINK\] description" where the optional \[LINK\] takes
+    /// the form of "(REL;TYPE)\[HREF\]". This argument maybe specified multiple times.
     #[arg(long, value_parser = parse_notice_or_remark)]
     notice: Vec<NoticeOrRemark>,
 
     /// Adds an object remark.
     ///
-    /// Takes the form of "[LINK] description" where the optional [LINK] takes
-    /// the form of "(REL;TYPE)[HREF]". This argument maybe specified multiple times.
+    /// Takes the form of "\[LINK\] description" where the optional \[LINK\] takes
+    /// the form of "(REL;TYPE)\[HREF\]". This argument maybe specified multiple times.
     #[arg(long, value_parser = parse_notice_or_remark)]
     remark: Vec<NoticeOrRemark>,
 

--- a/icann-rdap-srv/src/storage/data.rs
+++ b/icann-rdap-srv/src/storage/data.rs
@@ -332,7 +332,7 @@ pub async fn trigger_update(data_dir: &str) -> Result<(), RdapServerError> {
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
-    use cidr_utils::cidr::IpCidr;
+
     use icann_rdap_common::response::domain::Domain;
 
     use super::*;
@@ -376,8 +376,9 @@ mod tests {
         // GIVEN
         let template = Template::Network {
             network: Network::basic()
-                .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-                .build(),
+                .cidr("10.0.0.0/24")
+                .build()
+                .expect("cidr parsing"),
             ids: vec![NetworkId::builder()
                 .network_id(NetworkIdType::Cidr(
                     "10.0.0.0/24".parse().expect("ipnet parsing"),
@@ -400,8 +401,9 @@ mod tests {
         // GIVEN
         let template = Template::Network {
             network: Network::basic()
-                .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-                .build(),
+                .cidr("10.0.0.0/24")
+                .build()
+                .expect("cidr parsing"),
             ids: vec![NetworkId::builder()
                 .network_id(NetworkIdType::Range {
                     start_address: "10.0.0.0".to_string(),
@@ -431,8 +433,9 @@ mod tests {
         // THEN
         let expected = Template::Network {
             network: Network::basic()
-                .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-                .build(),
+                .cidr("10.0.0.0/24")
+                .build()
+                .expect("cidr parsing"),
             ids: vec![NetworkId::builder()
                 .network_id(NetworkIdType::Cidr(
                     "10.0.0.0/24".parse().expect("ipnet parsing"),
@@ -453,8 +456,9 @@ mod tests {
         // THEN
         let expected = Template::Network {
             network: Network::basic()
-                .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-                .build(),
+                .cidr("10.0.0.0/24")
+                .build()
+                .expect("cidr parsing"),
             ids: vec![NetworkId::builder()
                 .network_id(NetworkIdType::Range {
                     start_address: "10.0.0.0".to_string(),

--- a/icann-rdap-srv/tests/integration/storage/data.rs
+++ b/icann-rdap-srv/tests/integration/storage/data.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use cidr_utils::cidr::IpCidr;
 use icann_rdap_common::response::{
     autnum::Autnum, domain::Domain, entity::Entity, nameserver::Nameserver, network::Network,
 };
@@ -181,7 +180,7 @@ async fn GIVEN_data_dir_with_nameserver_WHEN_mem_init_THEN_nameserver_is_loaded(
     // GIVEN
     let ldh_name = "ns.foo.example";
     let temp = TestDir::temp();
-    let nameserver = Nameserver::basic().ldh_name(ldh_name).build();
+    let nameserver = Nameserver::basic().ldh_name(ldh_name).build().unwrap();
     let nameserver_file = temp.path("ns_foo_example.json");
     std::fs::write(
         nameserver_file,
@@ -213,7 +212,7 @@ async fn GIVEN_data_dir_with_nameserver_template_WHEN_mem_init_THEN_nameservers_
     let ldh2 = "ns.bar.example";
     let temp = TestDir::temp();
     let template = Template::Nameserver {
-        nameserver: Nameserver::basic().ldh_name("example").build(),
+        nameserver: Nameserver::basic().ldh_name("example").build().unwrap(),
         ids: vec![
             NameserverId::builder().ldh_name(ldh1).build(),
             NameserverId::builder().ldh_name(ldh2).build(),
@@ -247,7 +246,7 @@ async fn GIVEN_data_dir_with_autnum_WHEN_mem_init_THEN_autnum_is_loaded() {
     // GIVEN
     let num = 700u32;
     let temp = TestDir::temp();
-    let autnum = Autnum::basic().autnum(num).build();
+    let autnum = Autnum::basic().autnum_range(num..num).build();
     let autnum_file = temp.path("700.json");
     std::fs::write(
         autnum_file,
@@ -279,7 +278,7 @@ async fn GIVEN_data_dir_with_autnum_template_WHEN_mem_init_THEN_autnums_are_load
     let num2 = 800u32;
     let temp = TestDir::temp();
     let template = Template::Autnum {
-        autnum: Autnum::basic().autnum(0).build(),
+        autnum: Autnum::basic().autnum_range(0..0).build(),
         ids: vec![
             AutnumId::builder()
                 .start_autnum(num1)
@@ -322,8 +321,9 @@ async fn GIVEN_data_dir_with_network_WHEN_mem_init_THEN_network_is_loaded() {
     // GIVEN
     let temp = TestDir::temp();
     let network = Network::basic()
-        .cidr(IpCidr::from_str("10.0.0.0/24").expect("cidr parsing"))
-        .build();
+        .cidr("10.0.0.0/24")
+        .build()
+        .expect("cidr parsing");
     let net_file = temp.path("ten_net.json");
     std::fs::write(
         net_file,
@@ -361,8 +361,9 @@ async fn GIVEN_data_dir_with_network_template_with_cidr_WHEN_mem_init_THEN_netwo
     let temp = TestDir::temp();
     let template = Template::Network {
         network: Network::basic()
-            .cidr(IpCidr::from_str("1.1.1.1/32").expect("parsing cidr"))
-            .build(),
+            .cidr("1.1.1.1/32")
+            .build()
+            .expect("parsing cidr"),
         ids: vec![
             NetworkId::builder()
                 .network_id(NetworkIdType::Cidr(cidr1.parse().expect("parsing cidr")))
@@ -411,8 +412,9 @@ async fn GIVEN_data_dir_with_network_template_with_range_WHEN_mem_init_THEN_netw
     let temp = TestDir::temp();
     let template = Template::Network {
         network: Network::basic()
-            .cidr(IpCidr::from_str("1.1.1.1/32").expect("parsing cidr"))
-            .build(),
+            .cidr("1.1.1.1/32")
+            .build()
+            .expect("parsing cidr"),
         ids: vec![
             NetworkId::builder()
                 .network_id(NetworkIdType::Range {

--- a/icann-rdap-srv/tests/integration/storage/mem/mod.rs
+++ b/icann-rdap-srv/tests/integration/storage/mem/mod.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
 
-use cidr_utils::cidr::IpCidr;
 use icann_rdap_common::response::{
     autnum::Autnum,
     domain::Domain,
@@ -137,9 +136,14 @@ async fn GIVEN_nameserver_in_mem_WHEN_lookup_nameserver_by_ldh_THEN_nameserver_r
     // GIVEN
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
-    tx.add_nameserver(&Nameserver::basic().ldh_name("ns.foo.example").build())
-        .await
-        .expect("add nameserver in tx");
+    tx.add_nameserver(
+        &Nameserver::basic()
+            .ldh_name("ns.foo.example")
+            .build()
+            .unwrap(),
+    )
+    .await
+    .expect("add nameserver in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -181,14 +185,9 @@ async fn GIVEN_autnum_in_mem_WHEN_lookup_autnum_by_start_autnum_THEN_autnum_retu
     // GIVEN
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
-    tx.add_autnum(
-        &Autnum::basic_nums()
-            .start_autnum(700)
-            .end_autnum(710)
-            .build(),
-    )
-    .await
-    .expect("add autnum in tx");
+    tx.add_autnum(&Autnum::basic().autnum_range(700..710).build())
+        .await
+        .expect("add autnum in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -213,14 +212,9 @@ async fn GIVEN_autnum_in_mem_WHEN_lookup_autnum_by_end_autnum_THEN_autnum_return
     // GIVEN
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
-    tx.add_autnum(
-        &Autnum::basic_nums()
-            .start_autnum(700)
-            .end_autnum(710)
-            .build(),
-    )
-    .await
-    .expect("add autnum in tx");
+    tx.add_autnum(&Autnum::basic().autnum_range(700..710).build())
+        .await
+        .expect("add autnum in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -273,13 +267,9 @@ async fn GIVEN_network_in_mem_WHEN_lookup_network_by_address_THEN_network_return
     // GIVEN
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
-    tx.add_network(
-        &Network::basic()
-            .cidr(IpCidr::from_str(cidr).expect("cidr parsing"))
-            .build(),
-    )
-    .await
-    .expect("add network in tx");
+    tx.add_network(&Network::basic().cidr(cidr).build().expect("cidr parsing"))
+        .await
+        .expect("add network in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN
@@ -337,13 +327,9 @@ async fn GIVEN_contained_networks_in_mem_WHEN_lookup_network_by_address_THEN_mos
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
     for cidr in cidrs {
-        tx.add_network(
-            &Network::basic()
-                .cidr(IpCidr::from_str(cidr).expect("cidr parsing"))
-                .build(),
-        )
-        .await
-        .expect("add network in tx");
+        tx.add_network(&Network::basic().cidr(*cidr).build().expect("cidr parsing"))
+            .await
+            .expect("add network in tx");
     }
     tx.commit().await.expect("tx commit");
 
@@ -469,13 +455,9 @@ async fn GIVEN_network_in_mem_WHEN_lookup_network_by_cidr_THEN_network_returned(
     // GIVEN
     let mem = Mem::default();
     let mut tx = mem.new_tx().await.expect("new transaction");
-    tx.add_network(
-        &Network::basic()
-            .cidr(IpCidr::from_str(cidr).expect("cidr parsing"))
-            .build(),
-    )
-    .await
-    .expect("add network in tx");
+    tx.add_network(&Network::basic().cidr(cidr).build().expect("cidr parsing"))
+        .await
+        .expect("add network in tx");
     tx.commit().await.expect("tx commit");
 
     // WHEN


### PR DESCRIPTION
* `--help` now has information on where the cache is stored.
* fixed autnum bootstrapping bug
* fixed a cache bug that prevented non-Entity object classes from being deserialized from cache
* add `rdap_type` to the `--json-extra` output to help scripts determine the rdap object class
* added common parsing example
* a lot of cleanup and changes to the internal common API
* support for cidr0 extension
* moved from simplelog to tracing-subscriber for the cli
* README updates