### PR TITLE
Fix #39

### DIFF
--- a/icann-rdap-client/src/lib.rs
+++ b/icann-rdap-client/src/lib.rs
@@ -3,7 +3,7 @@
 #![doc = include_str!("../README.md")]
 use std::fmt::Display;
 
-use icann_rdap_common::response::RdapResponseError;
+use icann_rdap_common::{cache::HttpData, response::RdapResponseError};
 use reqwest::Url;
 use thiserror::Error;
 
@@ -30,9 +30,7 @@ pub enum RdapClientError {
 #[derive(Debug)]
 pub struct ParsingErrorInfo {
     pub text: String,
-    pub content_length: Option<u64>,
-    pub content_type: Option<String>,
-    pub url: Url,
+    pub http_data: HttpData,
     pub error: serde_json::Error,
 }
 
@@ -42,12 +40,14 @@ impl Display for ParsingErrorInfo {
             f,
             "Error: {}\n,Content Length: {}\nContent Type: {}\nUrl: {}\nText:\n{}\n",
             self.error,
-            self.content_length
+            self.http_data
+                .content_length
                 .map_or("No content length given".to_string(), |n| n.to_string()),
-            self.content_type
+            self.http_data
+                .content_type
                 .clone()
                 .unwrap_or("No content type given".to_string()),
-            self.url,
+            self.http_data.host,
             self.text
         )
     }


### PR DESCRIPTION
Implemented changes proposed in #39. Please note that this change breaks compatibility with previous version by removing (now redundant) `content_length`, `content_type` and `url` fields here:

https://github.com/icann/icann-rdap/blob/8b8478cd9b03c7b2a1fa24124aae4b3b7391aa02/icann-rdap-client/src/lib.rs#L33-L35

Removed fields should now be accessible as part of a new `http_data` field on `icann_rdap_client::RdapClientError::ParsingError` error variant (`content_length`, `content_type` and `host` fields respectively).

Minimal reproducible example of a (now supported) use case:
```rust
#[tokio::main]
async fn main() -> anyhow::Result<()> {
    let client_config = icann_rdap_common::client::ClientConfig::builder()
        .https_only(false)
        .follow_redirects(false)
        .build();
    
    let client = icann_rdap_common::client::create_client(&client_config)
        .expect("Failed to build RDAP library client");
    
    let query = icann_rdap_client::query::qtype::QueryType::from_str("10.0.0.0/8")?;

    // Will result in `icann_rdap_client::RdapClientError::ParsingError` because of
    // `follow_redirects(false)` in `client_config`
    let error = icann_rdap_client::query::request::rdap_request(
        "http://127.0.0.1/rdapbootstrap", // Locally running RDAP bootstrap server
        &query,
        client
    )
    .await
    .unwrap_err(); // PR adds `Debug` derive on `icann_rdap_client::query::request::ResponseData`

    match error {
	icann_rdap_client::RdapClientError::ParsingError(info) => {
		println!(
			"Should now send a request to: {}",
			info.http_data.location.expect("No location, strange!")
		)
	}
	_ => panic!("Something went wrong!"),
    }
}
```

Do let me know if any issues.