### PR TITLE
Change default to paging to none

### DIFF
--- a/icann-rdap-cli/README.md
+++ b/icann-rdap-cli/README.md
@@ -58,12 +58,22 @@ For more advanced usage, run `rdap --help` which should yield the extensive help
 Paging Output
 -------------
 
-By default, the client will attempt to determine if paging the output (showing information one page at a time)
-is appropriate. This is done by attempting to determine if the terminal is interactive or not. If the terminal
-is not interactive, paging will be turned off otherwise it will be on.
+The client has a built-in (embedded) pager. Use of this pager is controlled via the `RDAP_PAGING`
+environment variable and the `-P` command argument.
 
-You can explicitly control this behavior using the `-P` command argument such as `-P none` to specify no paging.
-This is also controlled via the `RDAP_PAGING` environmental variable (see configuration below).
+It takes three values:
+
+* "embedded" - use the built-in pager
+* "auto" - use the built-in pager if the program is being run from a terminal
+* "none" - use no paging
+
+For example, `-P embedded` will default to using the built-in pager.
+
+By default, the client will not use a pager.
+
+When set to "auto", the client determines if a pager is appropriate. 
+This is done by attempting to determine if the terminal is interactive or not. If the terminal
+is not interactive, paging will be turned off otherwise it will be on.
 
 Output Format
 -------------

--- a/icann-rdap-cli/src/main.rs
+++ b/icann-rdap-cli/src/main.rs
@@ -148,7 +148,7 @@ struct Cli {
         required = false,
         env = "RDAP_PAGING",
         value_enum,
-        default_value_t = PagerType::Auto,
+        default_value_t = PagerType::None,
     )]
     page_output: PagerType,
 

--- a/release.md
+++ b/release.md
@@ -6,6 +6,7 @@ with proper GitHub and crates.io credentials. Without both, this will
 fail.
 
 1. Install the Cargo release plugin (if it is not already installed): `cargo install cargo-release`
+1. Go to the 'dev' branch and get the latest changes: `git switch dev` and then `git pull`.
 1. On the 'dev' branch, use the cargo release plugin to bump either the patch, minor, or major version: `cargo release version patch -x`, `cargo release version minor -x` or `cargo release version major -x`.
 1. Run the tests: `cargo test`
 1. Commit these changes to git.


### PR DESCRIPTION
This PR changes the default for paging to be none because the built-in pager has some issues with copy/paste in many terminals. Until this is sorted out, the default should be none.