### PR TITLE
code to check IDNs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "chrono",
  "cidr-utils 0.6.1",
  "const_format",
+ "idna",
  "ipnet",
  "lazy_static",
  "prefix-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ http = "1.0"
 # hyper (http implementation used by axum)
 hyper = { version = "1.0", features = ["full"] }
 
+# internationalized domain names for applications
+idna = "0.5"
+
 # for use prefixmap
 ipnet = { version = "2.9", features = ["json"] }
 

--- a/icann-rdap-common/Cargo.toml
+++ b/icann-rdap-common/Cargo.toml
@@ -13,6 +13,7 @@ chrono.workspace = true
 cidr-utils.workspace = true
 const_format.workspace = true
 buildstructor.workspace = true
+idna.workspace = true
 ipnet.workspace = true
 lazy_static.workspace = true
 prefix-trie.workspace = true

--- a/icann-rdap-common/src/check/items.rs
+++ b/icann-rdap-common/src/check/items.rs
@@ -115,6 +115,26 @@ impl CheckItem {
             check: Check::DocumentataionName,
         }
     }
+    pub fn unicode_does_not_match_ldh() -> CheckItem {
+        CheckItem {
+            check_class: CheckClass::SpecificationWarning,
+            check: Check::UnicodeDoesNotMatchLdh,
+        }
+    }
+
+    // Unicode Name
+    pub fn invalid_unicode_domain_name() -> CheckItem {
+        CheckItem {
+            check_class: CheckClass::SpecificationError,
+            check: Check::InvalidUnicodeDomainName,
+        }
+    }
+    pub fn invalid_unicode_name() -> CheckItem {
+        CheckItem {
+            check_class: CheckClass::SpecificationError,
+            check: Check::InvalidUnicodeName,
+        }
+    }
 
     // Network or Autnum Name
     pub fn name_is_empty() -> CheckItem {

--- a/icann-rdap-common/src/check/mod.rs
+++ b/icann-rdap-common/src/check/mod.rs
@@ -193,6 +193,14 @@ pub enum Check {
     InvalidLdhName,
     #[strum(message = "Documentation domain name. See RFC 6761")]
     DocumentataionName,
+    #[strum(message = "Unicode name does not match LDH")]
+    UnicodeDoesNotMatchLdh,
+
+    // Unicode Name
+    #[strum(message = "unicodeName does not appear to be a domain name")]
+    InvalidUnicodeDomainName,
+    #[strum(message = "unicodeName does not appear to be valid Unicode")]
+    InvalidUnicodeName,
 
     // Network or Autnum Name
     #[strum(message = "name appears to be empty or only whitespace")]

--- a/icann-rdap-common/src/check/string.rs
+++ b/icann-rdap-common/src/check/string.rs
@@ -8,6 +8,9 @@ pub trait StringCheck {
     /// Tests if a string is an LDH doamin name. This is not to be confused with [StringCheck::is_ldh_string],
     /// which checks individual domain labels.
     fn is_ldh_domain_name(&self) -> bool;
+
+    /// Tests if a string is a Unicode domain name.
+    fn is_unicode_domain_name(&self) -> bool;
 }
 
 impl<T: ToString> StringCheck for T {
@@ -24,6 +27,11 @@ impl<T: ToString> StringCheck for T {
     fn is_ldh_domain_name(&self) -> bool {
         let s = self.to_string();
         s == "." || (!s.is_empty() && s.split_terminator('.').all(|s| s.is_ldh_string()))
+    }
+
+    fn is_unicode_domain_name(&self) -> bool {
+        let s = self.to_string();
+        s == "." || !s.is_whitespace_or_empty()
     }
 }
 
@@ -183,6 +191,25 @@ mod tests {
 
         // WHEN
         let actual = test_string.is_ldh_domain_name();
+
+        // THEN
+        assert_eq!(actual, expected);
+    }
+
+    #[rstest]
+    #[case("foo", true)]
+    #[case("", false)]
+    #[case(".", true)]
+    #[case("foo.bar", true)]
+    #[case("foo.bar.", true)]
+    fn GIVEN_string_WHEN_is_unicode_domain_name_THEN_correct_result(
+        #[case] test_string: &str,
+        #[case] expected: bool,
+    ) {
+        // GIVEN in parameters
+
+        // WHEN
+        let actual = test_string.is_unicode_domain_name();
 
         // THEN
         assert_eq!(actual, expected);

--- a/icann-rdap-common/src/response/domain.rs
+++ b/icann-rdap-common/src/response/domain.rs
@@ -155,6 +155,7 @@ impl Domain {
     #[builder(entry = "basic")]
     pub fn new_ldh<T: Into<String>>(
         ldh_name: T,
+        unicode_name: Option<String>,
         nameservers: Option<Vec<Nameserver>>,
         handle: Option<String>,
         remarks: Vec<crate::response::types::Remark>,
@@ -182,7 +183,59 @@ impl Domain {
                 .and_entities(entities)
                 .build(),
             ldh_name: Some(ldh_name.into()),
-            unicode_name: None,
+            unicode_name,
+            variants: None,
+            secure_dns: None,
+            nameservers,
+            public_ids: None,
+            network: None,
+        }
+    }
+
+    /// Builds an IDN object.
+    ///
+    /// ```rust
+    /// use icann_rdap_common::response::domain::Domain;
+    /// use icann_rdap_common::response::types::StatusValue;
+    ///
+    /// let domain = Domain::idn()
+    ///   .unicode_name("foo.example.com")
+    ///   .handle("foo_example_com-1")
+    ///   .status("active")
+    ///   .build();
+    /// ```
+    #[builder(entry = "idn")]
+    pub fn new_idn<T: Into<String>>(
+        ldh_name: Option<String>,
+        unicode_name: T,
+        nameservers: Option<Vec<Nameserver>>,
+        handle: Option<String>,
+        remarks: Vec<crate::response::types::Remark>,
+        links: Vec<crate::response::types::Link>,
+        events: Vec<crate::response::types::Event>,
+        statuses: Vec<String>,
+        port_43: Option<crate::response::types::Port43>,
+        entities: Vec<crate::response::entity::Entity>,
+        notices: Vec<crate::response::types::Notice>,
+    ) -> Self {
+        let entities = (!entities.is_empty()).then_some(entities);
+        let remarks = (!remarks.is_empty()).then_some(remarks);
+        let links = (!links.is_empty()).then_some(links);
+        let events = (!events.is_empty()).then_some(events);
+        let notices = (!notices.is_empty()).then_some(notices);
+        Self {
+            common: Common::builder().and_notices(notices).build(),
+            object_common: ObjectCommon::domain()
+                .and_handle(handle)
+                .and_remarks(remarks)
+                .and_links(links)
+                .and_events(events)
+                .and_status(to_option_status(statuses))
+                .and_port_43(port_43)
+                .and_entities(entities)
+                .build(),
+            ldh_name,
+            unicode_name: Some(unicode_name.into()),
             variants: None,
             secure_dns: None,
             nameservers,


### PR DESCRIPTION
This PR adds checks for valid unicodeName as IDNs and that if both ldhName and unicodeName are given that they need to match.