### PR TITLE
remove a-label only restriction on cli, add a-label query type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "cidr-utils 0.6.1",
  "const_format",
  "icann-rdap-common",
+ "idna",
  "lazy_static",
  "pct-str",
  "regex",

--- a/icann-rdap-cli/src/main.rs
+++ b/icann-rdap-cli/src/main.rs
@@ -240,6 +240,9 @@ enum QtypeArg {
     /// Domain Lookup
     Domain,
 
+    /// A-Label Domain Lookup
+    ALabel,
+
     /// Entity Lookup
     Entity,
 
@@ -520,6 +523,7 @@ fn query_type_from_cli(cli: &Cli) -> QueryType {
                 QtypeArg::V6Cidr => QueryType::IpV6Cidr(query_value),
                 QtypeArg::Autnum => QueryType::AsNumber(query_value),
                 QtypeArg::Domain => QueryType::Domain(query_value),
+                QtypeArg::ALabel => QueryType::ALable(query_value),
                 QtypeArg::Entity => QueryType::Entity(query_value),
                 QtypeArg::Ns => QueryType::Nameserver(query_value),
                 QtypeArg::EntityName => QueryType::EntityNameSearch(query_value),

--- a/icann-rdap-client/Cargo.toml
+++ b/icann-rdap-client/Cargo.toml
@@ -16,6 +16,7 @@ buildstructor.workspace = true
 cidr-utils.workspace = true
 chrono.workspace = true
 const_format.workspace = true
+idna.workspace = true
 lazy_static.workspace = true
 pct-str.workspace = true
 regex.workspace = true

--- a/icann-rdap-common/src/check/string.rs
+++ b/icann-rdap-common/src/check/string.rs
@@ -31,7 +31,12 @@ impl<T: ToString> StringCheck for T {
 
     fn is_unicode_domain_name(&self) -> bool {
         let s = self.to_string();
-        s == "." || !s.is_whitespace_or_empty()
+        s == "."
+            || (!s.is_empty()
+                && s.split_terminator('.').all(|s| {
+                    s.chars()
+                        .all(|c| c == '-' || (!c.is_ascii_punctuation() && !c.is_whitespace()))
+                }))
     }
 }
 
@@ -202,6 +207,8 @@ mod tests {
     #[case(".", true)]
     #[case("foo.bar", true)]
     #[case("foo.bar.", true)]
+    #[case("fo_o.bar.", false)]
+    #[case("fo o.bar.", false)]
     fn GIVEN_string_WHEN_is_unicode_domain_name_THEN_correct_result(
         #[case] test_string: &str,
         #[case] expected: bool,


### PR DESCRIPTION
The PR does the following:
* Removes the restriction that CLI domain lookups must be a-labels.
* Adds a specific query type for converting u-labels to a-labels and doing the query as an a-label
* Adds punctuation check to the is_unicode_name string utility function