### PR TITLE
Streamlined Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1397,6 +1397,8 @@ dependencies = [
  "const_format",
  "icann-rdap-common",
  "idna",
+ "jsonpath-rust",
+ "jsonpath_lib",
  "lazy_static",
  "pct-str",
  "regex",
@@ -1546,6 +1548,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0268078319393f8430e850ee9d4706aeced256d34cf104d216bb496777137162"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonpath_lib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa63191d68230cccb81c5aa23abd53ed64d83337cacbb25a7b8c7979523774f"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1993,6 +2021,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.41",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project"
@@ -2500,6 +2573,7 @@ version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -3301,6 +3375,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"

--- a/icann-rdap-cli/src/query.rs
+++ b/icann-rdap-cli/src/query.rs
@@ -6,7 +6,7 @@ use tracing::error;
 use tracing::info;
 
 use icann_rdap_client::{
-    md::{MdOptions, MdParams, ToMd},
+    md::{redacted::replace_redacted_items, MdOptions, MdParams, ToMd},
     query::{qtype::QueryType, request::ResponseData},
     request::{RequestData, RequestResponse, RequestResponses, SourceType},
 };
@@ -84,7 +84,19 @@ async fn do_domain_query<'a, W: std::io::Write>(
                 source_host: &source_host,
                 source_type: SourceType::DomainRegistry,
             };
-            transactions = do_output(processing_params, &req_data, &response, write, transactions)?;
+            let replaced_rdap = replace_redacted_items(response.rdap.clone());
+            let replaced_data = ResponseData {
+                rdap: replaced_rdap,
+                // copy other fields from `response`
+                ..response.clone()
+            };
+            transactions = do_output(
+                processing_params,
+                &req_data,
+                &replaced_data,
+                write,
+                transactions,
+            )?;
             let regr_source_host;
             let regr_req_data: RequestData;
             if let Some(url) = get_related_link(&response.rdap).first() {
@@ -135,7 +147,19 @@ async fn do_inr_query<'a, W: std::io::Write>(
                 source_host: &source_host,
                 source_type: SourceType::RegionalInternetRegistry,
             };
-            transactions = do_output(processing_params, &req_data, &response, write, transactions)?;
+            let replaced_rdap = replace_redacted_items(response.rdap.clone());
+            let replaced_data = ResponseData {
+                rdap: replaced_rdap,
+                // copy other fields from `response`
+                ..response.clone()
+            };
+            transactions = do_output(
+                processing_params,
+                &req_data,
+                &replaced_data,
+                write,
+                transactions,
+            )?;
             do_final_output(processing_params, write, transactions)?;
         }
         Err(error) => return Err(error),
@@ -169,7 +193,19 @@ async fn do_basic_query<'a, W: std::io::Write>(
                     source_type: SourceType::UncategorizedRegistry,
                 }
             };
-            transactions = do_output(processing_params, &req_data, &response, write, transactions)?;
+            let replaced_rdap = replace_redacted_items(response.rdap.clone());
+            let replaced_data = ResponseData {
+                rdap: replaced_rdap,
+                // copy other fields from `response`
+                ..response.clone()
+            };
+            transactions = do_output(
+                processing_params,
+                &req_data,
+                &replaced_data,
+                write,
+                transactions,
+            )?;
             do_final_output(processing_params, write, transactions)?;
         }
         Err(error) => return Err(error),

--- a/icann-rdap-client/Cargo.toml
+++ b/icann-rdap-client/Cargo.toml
@@ -27,6 +27,9 @@ strum.workspace = true
 strum_macros.workspace = true
 thiserror.workspace = true
 
+jsonpath-rust = "=0.5.0"
+jsonpath_lib = "0.3.0"
+
 [dev-dependencies]
 
 # fixture testings

--- a/icann-rdap-client/src/md/redacted.rs
+++ b/icann-rdap-client/src/md/redacted.rs
@@ -1,6 +1,13 @@
+use std::str::FromStr;
+
 use icann_rdap_common::response::redacted::Redacted;
+use jsonpath::replace_with;
+use jsonpath_lib as jsonpath;
+use jsonpath_rust::{JsonPathFinder, JsonPathInst};
+use serde_json::{json, Value};
 
 use super::{string::StringUtil, table::MultiPartTable, MdOptions, MdParams, ToMd};
+use icann_rdap_common::response::RdapResponse;
 
 impl ToMd for &[Redacted] {
     fn to_md(&self, params: MdParams) -> String {
@@ -59,5 +66,197 @@ impl ToMd for &[Redacted] {
         md.push_str(&table.to_md(params));
         md.push('\n');
         md
+    }
+}
+
+// this is our public entry point
+pub fn replace_redacted_items(orignal_response: RdapResponse) -> RdapResponse {
+    // convert the RdapResponse to a string
+    let rdap_json = serde_json::to_string(&orignal_response).unwrap();
+
+    // Redaction is not a top-level entity so we have to check the JSON
+    // to see if anything exists in the way of "redacted", this should find it in the rdapConformance
+    if !rdap_json.contains("\"redacted\"") {
+        // If there are no redactions, return the original response
+        return orignal_response;
+    }
+
+    // convert the string to a JSON Value
+    let mut rdap_json_response: Value = serde_json::from_str(&rdap_json).unwrap();
+
+    // this double checks to see if "redacted" is an array
+    if rdap_json_response["redacted"].as_array().is_none() {
+        // If "redacted" is not an array, return the original response
+        return orignal_response;
+    }
+
+    // Initialize the final response with the original response
+    let mut response = orignal_response;
+    // pull the redacted array out of the JSON
+    let redacted_array_option = rdap_json_response["redacted"].as_array().cloned();
+
+    // if there are any redactions we need to do some modifications
+    if let Some(ref redacted_array) = redacted_array_option {
+        let new_json_response = convert_redactions(&mut rdap_json_response, redacted_array).clone();
+        // convert the Value back to a RdapResponse
+        response = serde_json::from_value(new_json_response).unwrap();
+    }
+
+    // send the response back so we can display it to the client
+    response
+}
+
+fn convert_redactions<'a>(
+    rdap_json_response: &'a mut Value,
+    redacted_array: &'a [Value],
+) -> &'a mut Value {
+    for item in redacted_array {
+        let item_map = item.as_object().unwrap();
+        let post_path = get_string_from_map(item_map, "postPath");
+        let method = get_string_from_map(item_map, "method");
+
+        // if method doesn't equal emptyValue or partialValue, we don't need to do anything, we can skip to the next item
+        if method != "emptyValue" && method != "partialValue" && !post_path.is_empty() {
+            continue;
+        }
+
+        match JsonPathInst::from_str(&post_path) {
+            Ok(json_path) => {
+                let finder =
+                    JsonPathFinder::new(Box::new(rdap_json_response.clone()), Box::new(json_path));
+                let matches = finder.find_as_path();
+                if let Value::Array(paths) = matches {
+                    if paths.is_empty() {
+                        continue; // we don't need to do anything, we can skip to the next item
+                    } else {
+                        for path_value in paths {
+                            if let Value::String(found_path) = path_value {
+                                let no_value = Value::String("NO_VALUE".to_string());
+                                let json_pointer = convert_to_json_pointer_path(&found_path);
+                                let value_at_path = rdap_json_response
+                                    .pointer(&json_pointer)
+                                    .unwrap_or(&no_value);
+                                if value_at_path.is_string() {
+                                    // grab the value at the end point of the JSON path
+                                    let end_of_path_value =
+                                        match rdap_json_response.pointer(&json_pointer) {
+                                            Some(value) => value.clone(),
+                                            None => {
+                                                continue;
+                                            }
+                                        };
+                                    let replaced_json = replace_with(
+                                        rdap_json_response.clone(),
+                                        &found_path,
+                                        &mut |x| {
+                                            // STRING ONLY! This is the only spot where we are ACTUALLY replacing or updating something
+                                            if x.is_string() {
+                                                match x.as_str() {
+                                                    Some("") => Some(json!("*REDACTED*")),
+                                                    Some(s) => Some(json!(format!("*{}*", s))),
+                                                    _ => Some(json!("*REDACTED*")),
+                                                }
+                                            } else {
+                                                Some(end_of_path_value.clone()) // it isn't a string, put it back in there
+                                            }
+                                        },
+                                    );
+                                    match replaced_json {
+                                        Ok(new_json) => *rdap_json_response = new_json,
+                                        _ => {
+                                            // why did we fail to modify the JSON?
+                                        }
+                                    };
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {
+                // do nothing
+            }
+        }
+    }
+
+    rdap_json_response
+}
+
+// utility functions
+fn convert_to_json_pointer_path(path: &str) -> String {
+    let pointer_path = path
+        .trim_start_matches('$')
+        .replace('.', "/")
+        .replace("['", "/")
+        .replace("']", "")
+        .replace('[', "/")
+        .replace(']', "")
+        .replace("//", "/");
+    pointer_path
+}
+
+fn get_string_from_map(map: &serde_json::Map<String, Value>, key: &str) -> String {
+    map.get(key)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use serde_json::Value;
+    use std::error::Error;
+    use std::fs::File;
+    use std::io::Read;
+
+    fn process_redacted_file(file_path: &str) -> Result<String, Box<dyn Error>> {
+        let mut file = File::open(file_path)?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        // this has to be setup very specifically, just like replace_redacted_items is setup.
+        let mut rdap_json_response: Value = serde_json::from_str(&contents)?;
+        let redacted_array_option = rdap_json_response["redacted"].as_array().cloned();
+        // we are testing parse_redacted_json here -- just the JSON transforms
+        if let Some(redacted_array) = redacted_array_option {
+            crate::md::redacted::convert_redactions(&mut rdap_json_response, &redacted_array);
+        } else {
+            assert!(false, "No redacted array found in the JSON");
+        }
+        let pretty_json = serde_json::to_string_pretty(&rdap_json_response)?;
+        println!("{}", pretty_json);
+        Ok(pretty_json)
+    }
+
+    #[test]
+    fn test_process_empty_value() {
+        let expected_output =
+            std::fs::read_to_string("src/test_files/example-1_empty_value-expected.json").unwrap();
+        let output = process_redacted_file("src/test_files/example-1_empty_value.json").unwrap();
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn test_process_partial_value() {
+        let expected_output =
+            std::fs::read_to_string("src/test_files/example-2_partial_value-expected.json")
+                .unwrap();
+        let output = process_redacted_file("src/test_files/example-2_partial_value.json").unwrap();
+        assert_eq!(output, expected_output);
+    }
+
+    #[test]
+    fn test_process_dont_replace_number() {
+        let expected_output = std::fs::read_to_string(
+            "src/test_files/example-3-dont_replace_redaction_of_a_number.json",
+        )
+        .unwrap();
+        // we don't need an expected for this one, it should remain unchanged
+        let output = process_redacted_file(
+            "src/test_files/example-3-dont_replace_redaction_of_a_number.json",
+        )
+        .unwrap();
+        assert_eq!(output, expected_output);
     }
 }

--- a/icann-rdap-client/src/test_files/example-1_empty_value-expected.json
+++ b/icann-rdap-client/src/test_files/example-1_empty_value-expected.json
@@ -1,0 +1,259 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "redacted"
+  ],
+  "objectClassName": "domain",
+  "ldhName": "example-1.net",
+  "secureDNS": {
+    "delegationSigned": false
+  },
+  "notices": [
+    {
+      "title": "Terms of Use",
+      "description": [
+        "Service subject to Terms of Use."
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://www.example.com/terms-of-use",
+          "type": "text/html",
+          "value": "https://www.example.com/terms-of-use"
+        }
+      ]
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns1.example.com"
+    },
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns2.example.com"
+    }
+  ],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "123",
+      "roles": [
+        "registrar"
+      ],
+      "publicIds": [
+        {
+          "type": "IANA Registrar ID",
+          "identifier": "1"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Example Registrar Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 100",
+              "123 Example Dr.",
+              "Dulles",
+              "VA",
+              "20166-6503",
+              "US"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "contact@organization.example"
+          ],
+          [
+            "tel",
+            {
+              "type": "voice"
+            },
+            "uri",
+            "tel:+1.7035555555"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "uri",
+            "tel:+1.7035555556"
+          ]
+        ]
+      ],
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "roles": [
+            "abuse"
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Abuse Contact"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "abuse@organization.example"
+              ],
+              [
+                "tel",
+                {
+                  "type": "voice"
+                },
+                "uri",
+                "tel:+1.7035555555"
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "XXXX",
+      "roles": [
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "*REDACTED*"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              "",
+              "",
+              "QC",
+              "",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "YYYY",
+      "roles": [
+        "technical"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "Example Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 1234",
+              "4321 Rue Somewhere",
+              "Quebec",
+              "QC",
+              "G1V 2M2",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "1997-06-03T00:00:00Z"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "2020-05-28T01:35:00Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2021-06-03T04:00:00Z"
+    }
+  ],
+  "status": [
+    "server delete prohibited",
+    "server update prohibited",
+    "server transfer prohibited",
+    "client transfer prohibited"
+  ],
+  "redacted": [
+    {
+      "name": {
+        "description": "Registrant Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='fn')][3]",
+      "pathLang": "jsonpath",
+      "method": "emptyValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    }
+  ]
+}

--- a/icann-rdap-client/src/test_files/example-1_empty_value.json
+++ b/icann-rdap-client/src/test_files/example-1_empty_value.json
@@ -1,0 +1,240 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "redacted"
+  ],
+  "objectClassName": "domain",
+  "ldhName": "example-1.net",
+  "secureDNS": { "delegationSigned": false },
+  "notices": [
+    {
+      "title": "Terms of Use",
+      "description": [ "Service subject to Terms of Use." ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://www.example.com/terms-of-use",
+          "type": "text/html",
+          "value": "https://www.example.com/terms-of-use"
+        }
+      ]
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver", "ldhName": "ns1.example.com" },
+    {
+      "objectClassName": "nameserver", "ldhName": "ns2.example.com" }
+  ],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "123",
+      "roles": [ "registrar" ],
+      "publicIds": [
+        { "type": "IANA Registrar ID", "identifier": "1" }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Example Registrar Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 100",
+              "123 Example Dr.",
+              "Dulles",
+              "VA",
+              "20166-6503",
+              "US"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "contact@organization.example"
+          ],
+          [
+            "tel",
+            {
+              "type": "voice"
+            },
+            "uri",
+            "tel:+1.7035555555"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "uri",
+            "tel:+1.7035555556"
+          ]
+        ]
+      ],
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "roles": [
+            "abuse"
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Abuse Contact"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "abuse@organization.example"
+              ],
+              [
+                "tel",
+                {
+                  "type": "voice"
+                },
+                "uri",
+                "tel:+1.7035555555"
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "XXXX",
+      "roles": [
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              "",
+              "",
+              "QC",
+              "",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "YYYY",
+      "roles": [
+        "technical"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "Example Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 1234",
+              "4321 Rue Somewhere",
+              "Quebec",
+              "QC",
+              "G1V 2M2",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration", "eventDate": "1997-06-03T00:00:00Z"
+    },
+    {
+      "eventAction": "last changed", "eventDate": "2020-05-28T01:35:00Z"
+    },
+    {
+      "eventAction": "expiration", "eventDate": "2021-06-03T04:00:00Z"
+    }
+  ],
+  "status": [
+    "server delete prohibited", "server update prohibited", "server transfer prohibited", "client transfer prohibited"
+  ],
+  "redacted": [
+    {
+      "name": {
+        "description": "Registrant Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='fn')][3]",
+      "pathLang": "jsonpath",
+      "method": "emptyValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    }
+  ]
+}

--- a/icann-rdap-client/src/test_files/example-2_partial_value-expected.json
+++ b/icann-rdap-client/src/test_files/example-2_partial_value-expected.json
@@ -1,0 +1,302 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "redacted"
+  ],
+  "objectClassName": "domain",
+  "ldhName": "example-3.net",
+  "secureDNS": {
+    "delegationSigned": false
+  },
+  "notices": [
+    {
+      "title": "Terms of Use",
+      "description": [
+        "Service subject to Terms of Use."
+      ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://www.example.com/terms-of-use",
+          "type": "text/html",
+          "value": "https://www.example.com/terms-of-use"
+        }
+      ]
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns1.example.com"
+    },
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns2.example.com"
+    }
+  ],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "123",
+      "roles": [
+        "registrar"
+      ],
+      "publicIds": [
+        {
+          "type": "IANA Registrar ID",
+          "identifier": "1"
+        }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Example Registrar Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 100",
+              "123 Example Dr.",
+              "Dulles",
+              "VA",
+              "20166-6503",
+              "US"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "contact@organization.example"
+          ],
+          [
+            "tel",
+            {
+              "type": "voice"
+            },
+            "uri",
+            "tel:+1.7035555555"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "uri",
+            "tel:+1.7035555556"
+          ]
+        ]
+      ],
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "roles": [
+            "abuse"
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Abuse Contact"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "abuse@organization.example"
+              ],
+              [
+                "tel",
+                {
+                  "type": "voice"
+                },
+                "uri",
+                "tel:+1.7035555555"
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "XXXX",
+      "roles": [
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "*REDACTED*"
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "*REDACTED*",
+              "*REDACTED*",
+              "*REDACTED*",
+              "*REDACTED*",
+              "QC",
+              "*REDACTED*",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "YYYY",
+      "roles": [
+        "technical"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "*REDACTED*"
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "Example Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 1234",
+              "4321 Rue Somewhere",
+              "Quebec",
+              "QC",
+              "G1V 2M2",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "1997-06-03T00:00:00Z"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "2020-05-28T01:35:00Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2021-06-03T04:00:00Z"
+    }
+  ],
+  "status": [
+    "server delete prohibited",
+    "server update prohibited",
+    "server transfer prohibited",
+    "client transfer prohibited"
+  ],
+  "redacted": [
+    {
+      "name": {
+        "description": "Registrant Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='fn')][3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant Street"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][:3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant City"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant Postal Code"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][5]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Technical Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='technical')].vcardArray[1][?(@[0]=='fn')][3]",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    }
+  ]
+}

--- a/icann-rdap-client/src/test_files/example-2_partial_value.json
+++ b/icann-rdap-client/src/test_files/example-2_partial_value.json
@@ -1,0 +1,283 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "redacted"
+  ],
+  "objectClassName": "domain",
+  "ldhName": "example-3.net",
+  "secureDNS": { "delegationSigned": false },
+  "notices": [
+    {
+      "title": "Terms of Use",
+      "description": [ "Service subject to Terms of Use." ],
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://www.example.com/terms-of-use",
+          "type": "text/html",
+          "value": "https://www.example.com/terms-of-use"
+        }
+      ]
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver", "ldhName": "ns1.example.com" },
+    {
+      "objectClassName": "nameserver", "ldhName": "ns2.example.com" }
+  ],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "123",
+      "roles": [ "registrar" ],
+      "publicIds": [
+        { "type": "IANA Registrar ID", "identifier": "1" }
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Example Registrar Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 100",
+              "123 Example Dr.",
+              "Dulles",
+              "VA",
+              "20166-6503",
+              "US"
+            ]
+          ],
+          [
+            "email",
+            {},
+            "text",
+            "contact@organization.example"
+          ],
+          [
+            "tel",
+            {
+              "type": "voice"
+            },
+            "uri",
+            "tel:+1.7035555555"
+          ],
+          [
+            "tel",
+            {
+              "type": "fax"
+            },
+            "uri",
+            "tel:+1.7035555556"
+          ]
+        ]
+      ],
+      "entities": [
+        {
+          "objectClassName": "entity",
+          "roles": [
+            "abuse"
+          ],
+          "vcardArray": [
+            "vcard",
+            [
+              [
+                "version",
+                {},
+                "text",
+                "4.0"
+              ],
+              [
+                "fn",
+                {},
+                "text",
+                "Abuse Contact"
+              ],
+              [
+                "email",
+                {},
+                "text",
+                "abuse@organization.example"
+              ],
+              [
+                "tel",
+                {
+                  "type": "voice"
+                },
+                "uri",
+                "tel:+1.7035555555"
+              ]
+            ]
+          ]
+        }
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "XXXX",
+      "roles": [
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "",
+              "",
+              "",
+              "QC",
+              "",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "YYYY",
+      "roles": [
+        "technical"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ],
+          [
+            "org",
+            {},
+            "text",
+            "Example Inc."
+          ],
+          [
+            "adr",
+            {},
+            "text",
+            [
+              "",
+              "Suite 1234",
+              "4321 Rue Somewhere",
+              "Quebec",
+              "QC",
+              "G1V 2M2",
+              "Canada"
+            ]
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration", "eventDate": "1997-06-03T00:00:00Z"
+    },
+    {
+      "eventAction": "last changed", "eventDate": "2020-05-28T01:35:00Z"
+    },
+    {
+      "eventAction": "expiration", "eventDate": "2021-06-03T04:00:00Z"
+    }
+  ],
+  "status": [
+    "server delete prohibited", "server update prohibited", "server transfer prohibited", "client transfer prohibited"
+  ],
+  "redacted": [
+    {
+      "name": {
+        "description": "Registrant Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='fn')][3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant Street"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][:3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant City"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][3]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Registrant Postal Code"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='registrant')].vcardArray[1][?(@[0]=='adr')][3][5]",
+      "pathLang": "jsonpath",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    },
+    {
+      "name": {
+        "description": "Technical Name"
+      },
+      "postPath": "$.entities[?(@.roles[0]=='technical')].vcardArray[1][?(@[0]=='fn')][3]",
+      "method": "partialValue",
+      "reason": {
+        "description": "Server policy"
+      }
+    }
+  ]
+}

--- a/icann-rdap-client/src/test_files/example-3-dont_replace_redaction_of_a_number.json
+++ b/icann-rdap-client/src/test_files/example-3-dont_replace_redaction_of_a_number.json
@@ -1,0 +1,212 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "redacted"
+  ],
+  "objectClassName": "domain",
+  "handle": "PPP",
+  "ldhName": "0.2.192.in-addr.arpa",
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns1.rir.example"
+    },
+    {
+      "objectClassName": "nameserver",
+      "ldhName": "ns2.rir.example"
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": true,
+    "dsData": [
+      {
+        "keyTag": 25345,
+        "algorithm": 8,
+        "digestType": 2,
+        "digest": "2788970E18EA14...C890C85B8205B94"
+      }
+    ]
+  },
+  "remarks": [
+    {
+      "description": [
+        "She sells sea shells down by the sea shore.",
+        "Originally written by Terry Sullivan."
+      ]
+    }
+  ],
+  "links": [
+    {
+      "value": "https://example.net/domain/0.2.192.in-addr.arpa",
+      "rel": "self",
+      "href": "https://example.net/domain/0.2.192.in-addr.arpa",
+      "type": "application/rdap+json"
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventDate": "1990-12-31T23:59:59Z"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "1991-12-31T23:59:59Z",
+      "eventActor": "joe@example.com"
+    }
+  ],
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "XXXX",
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "Joe User"
+          ],
+          [
+            "kind",
+            {},
+            "text",
+            "individual"
+          ],
+          [
+            "lang",
+            {
+              "pref": "1"
+            },
+            "language-tag",
+            "fr"
+          ],
+          [
+            "lang",
+            {
+              "pref": "2"
+            },
+            "language-tag",
+            "en"
+          ],
+          [
+            "org",
+            {
+              "type": "work"
+            },
+            "text",
+            "Example"
+          ],
+          [
+            "title",
+            {},
+            "text",
+            "Research Scientist"
+          ],
+          [
+            "role",
+            {},
+            "text",
+            "Project Lead"
+          ],
+          [
+            "adr",
+            {
+              "type": "work"
+            },
+            "text",
+            [
+              "",
+              "Suite 1234",
+              "4321 Rue Somewhere",
+              "Quebec",
+              "QC",
+              "G1V 2M2",
+              "Canada"
+            ]
+          ],
+          [
+            "tel",
+            {
+              "type": [
+                "work",
+                "voice"
+              ],
+              "pref": "1"
+            },
+            "uri",
+            "tel:+1-555-555-1234;ext=102"
+          ],
+          [
+            "email",
+            {
+              "type": "work"
+            },
+            "text",
+            "joe.user@example.com"
+          ]
+        ]
+      ],
+      "roles": [
+        "registrant"
+      ],
+      "remarks": [
+        {
+          "description": [
+            "She sells sea shells down by the sea shore.",
+            "Originally written by Terry Sullivan."
+          ]
+        }
+      ],
+      "links": [
+        {
+          "value": "https://example.net/entity/XXXX",
+          "rel": "self",
+          "href": "https://example.net/entity/XXXX",
+          "type": "application/rdap+json"
+        }
+      ],
+      "events": [
+        {
+          "eventAction": "registration",
+          "eventDate": "1990-12-31T23:59:59Z"
+        },
+        {
+          "eventAction": "last changed",
+          "eventDate": "1991-12-31T23:59:59Z",
+          "eventActor": "joe@example.com"
+        }
+      ]
+    }
+  ],
+  "network": {
+    "objectClassName": "ip network",
+    "handle": "XXXX-RIR",
+    "startAddress": "192.0.2.0",
+    "endAddress": "192.0.2.255",
+    "ipVersion": "v4",
+    "name": "NET-RTR-1",
+    "type": "DIRECT ALLOCATION",
+    "country": "AU",
+    "parentHandle": "YYYY-RIR",
+    "status": [
+      "active"
+    ]
+  },
+  "redacted": [
+    {
+      "name": {
+        "description": "Registrant keyTag"
+      },
+      "postPath": "$['secureDNS']['dsData'][0]['keyTag']",
+      "pathLang": "jsonpath",
+      "method": "partialValue"
+    }
+  ]
+}


### PR DESCRIPTION
This is a severely minimalistic version with no RedactedInfo object. We never made redacted a top-level object and to get a redacted object we would have to know what we already have and walk it ... but it's much simpler to go directly to the redacted array. And for each one of those all we actually need from it is the postPath and the method. This has no flexibility, don't put a postPath and don't say your partialValue or a emptyValue, then no soup for you.  