### PR TITLE
adding Send+Sync supertraits to BootstrapStore for smoother async exp…

### DIFF
--- a/icann-rdap-client/src/query/bootstrap.rs
+++ b/icann-rdap-client/src/query/bootstrap.rs
@@ -16,7 +16,7 @@ use super::qtype::QueryType;
 const SECONDS_IN_WEEK: i64 = 604800;
 
 /// Defines a trait for things that store bootstrap registries.
-pub trait BootstrapStore {
+pub trait BootstrapStore: Send + Sync {
     /// Called when store is checked to see if it has a valid bootstrap registry.
     ///
     /// This method should return false (i.e. `Ok(false)``) if the registry doesn't
@@ -162,6 +162,9 @@ pub struct MemoryBootstrapStore {
     dns: Arc<RwLock<Option<(IanaRegistry, HttpData)>>>,
     tag: Arc<RwLock<Option<(IanaRegistry, HttpData)>>>,
 }
+
+unsafe impl Send for MemoryBootstrapStore {}
+unsafe impl Sync for MemoryBootstrapStore {}
 
 impl Default for MemoryBootstrapStore {
     fn default() -> Self {


### PR DESCRIPTION
I tried using the library in an async context (in a Tauri app within a `#[tauri:command]`) and went through hell because the compiler complained `BootstrapStore` doesn't implement `Send`. 

I trivially modified the trait and its implementation (`MemoryBootstrapStore`) to implement both `Send` and `Sync`.

It works in my app and passes unit-tests.