### PR TITLE
[WIP] gTLD whois output: Add support for missing roles and makes output more "ICANN-compliant"

### DIFF
--- a/icann-rdap-client/src/gtld/domain.rs
+++ b/icann-rdap-client/src/gtld/domain.rs
@@ -224,26 +224,35 @@ mod tests {
     fn test_ms_click_response() {
         let expected_output =
             std::fs::read_to_string("src/test_files/microsoft.click-expected.gtld").unwrap();
+        eprintln!("--- EXPECTED ---{expected_output}--- ---");
 
-        let output = process_gtld_file("src/test_files/microsoft.click.json").unwrap();
-        assert_eq!(output, expected_output);
+        let actual = process_gtld_file("src/test_files/microsoft.click.json").unwrap();
+        eprintln!("--- ACTUAL ---{actual}--- ---");
+
+        assert_eq!(actual, expected_output);
     }
 
     #[test]
     fn test_lemonde_response() {
         let expected_output =
             std::fs::read_to_string("src/test_files/lemonde.fr-expected.gtld").unwrap();
+        eprintln!("--- EXPECTED ---{expected_output}--- ---");
 
-        let output = process_gtld_file("src/test_files/lemonde.fr.json").unwrap();
-        assert_eq!(output, expected_output);
+        let actual = process_gtld_file("src/test_files/lemonde.fr.json").unwrap();
+        eprintln!("--- ACTUAL ---{actual}--- ---");
+
+        assert_eq!(actual, expected_output);
     }
 
     #[test]
     fn test_moscow_response() {
         let expected_output =
             std::fs::read_to_string("src/test_files/home.moscow-expected.gtld").unwrap();
+        eprintln!("--- EXPECTED ---{expected_output}--- ---");
 
-        let output = process_gtld_file("src/test_files/home.moscow.json").unwrap();
-        assert_eq!(output, expected_output);
+        let actual = process_gtld_file("src/test_files/home.moscow.json").unwrap();
+        eprintln!("--- ACTUAL ---{actual}--- ---");
+
+        assert_eq!(actual, expected_output);
     }
 }

--- a/icann-rdap-client/src/gtld/entity.rs
+++ b/icann-rdap-client/src/gtld/entity.rs
@@ -32,7 +32,9 @@ impl ToGtldWhois for Option<Vec<Entity>> {
                         let role_info = extract_role_info(vcard_array, params);
                         // Now use role_info to append to formatted_data
                         if !role_info.name.is_empty() {
-                            if ["registrar", "reseller", "sponsor", "proxy"].contains(&role.as_str()) {
+                            if ["registrar", "reseller", "sponsor", "proxy"]
+                                .contains(&role.as_str())
+                            {
                                 formatted_data +=
                                     &format!("{}: {}\n", params.label, role_info.name);
                             } else {
@@ -56,8 +58,7 @@ impl ToGtldWhois for Option<Vec<Entity>> {
                                 &format!("{} Phone: {}\n", params.label, role_info.phone);
                         }
                         if !role_info.fax.is_empty() {
-                            formatted_data +=
-                                &format!("{} Fax: {}\n", params.label, role_info.fax);
+                            formatted_data += &format!("{} Fax: {}\n", params.label, role_info.fax);
                         }
 
                         // Special Sauce for Registrar IANA ID and Abuse Contact
@@ -136,10 +137,7 @@ fn format_address_with_label(
     postal_address.to_gtld_whois(params).to_string()
 }
 
-fn extract_role_info(
-    vcard_array: &[serde_json::Value],
-    params: &mut GtldParams,
-) -> RoleInfo {
+fn extract_role_info(vcard_array: &[serde_json::Value], params: &mut GtldParams) -> RoleInfo {
     let contact = match Contact::from_vcard(vcard_array) {
         Some(contact) => contact,
         None => return RoleInfo::default(),

--- a/icann-rdap-client/src/gtld/entity.rs
+++ b/icann-rdap-client/src/gtld/entity.rs
@@ -8,30 +8,60 @@ use {
 
 impl ToGtldWhois for Option<Vec<Entity>> {
     fn to_gtld_whois(&self, params: &mut GtldParams) -> String {
-        let mut front_formatted_data = String::new();
         let mut formatted_data = String::new();
 
         if let Some(entities) = self {
             for entity in entities {
                 for role in entity.roles() {
-                    match role.as_str() {
-                        "registrar" => {
-                            if let Some(vcard_array) = &entity.vcard_array {
-                                let role_info = extract_role_info(role, vcard_array, params);
-                                // Now use role_info to append to formatted_data
-                                if !role_info.name.is_empty() {
-                                    front_formatted_data +=
-                                        &format!("{}: {}\n", cfl(role), role_info.name);
-                                }
-                                if !role_info.org.is_empty() {
-                                    front_formatted_data +=
-                                        &format!("{} Organization: {}\n", cfl(role), role_info.org);
-                                }
-                                if !role_info.adr.is_empty() {
-                                    front_formatted_data += &role_info.adr;
-                                }
+                    let label = match role.as_str() {
+                        "registrant" => "Registrant",
+                        "technical" => "Tech",
+                        "administrative" => "Admin",
+                        "billing" => "Billing",
+                        "registrar" => "Registrar",
+                        "reseller" => "Reseller",
+                        "sponsor" => "Sponsor",
+                        "proxy" => "Proxy",
+                        "notifications" => "Notifications",
+                        "noc" => "NOC",
+                        _ => continue,
+                    };
+                    params.label = label.to_string();
+
+                    if let Some(vcard_array) = &entity.vcard_array {
+                        let role_info = extract_role_info(vcard_array, params);
+                        // Now use role_info to append to formatted_data
+                        if !role_info.name.is_empty() {
+                            if ["registrar", "reseller", "sponsor", "proxy"].contains(&role.as_str()) {
+                                formatted_data +=
+                                    &format!("{}: {}\n", params.label, role_info.name);
+                            } else {
+                                formatted_data +=
+                                    &format!("{} Name: {}\n", params.label, role_info.name);
                             }
-                            // Special Sauce for Registrar IANA ID and Abuse Contact
+                        }
+                        if !role_info.org.is_empty() {
+                            formatted_data +=
+                                &format!("{} Organization: {}\n", params.label, role_info.org);
+                        }
+                        if !role_info.adr.is_empty() {
+                            formatted_data += &role_info.adr;
+                        }
+                        if !role_info.email.is_empty() {
+                            formatted_data +=
+                                &format!("{} Email: {}\n", params.label, role_info.email);
+                        }
+                        if !role_info.phone.is_empty() {
+                            formatted_data +=
+                                &format!("{} Phone: {}\n", params.label, role_info.phone);
+                        }
+                        if !role_info.fax.is_empty() {
+                            formatted_data +=
+                                &format!("{} Fax: {}\n", params.label, role_info.fax);
+                        }
+
+                        // Special Sauce for Registrar IANA ID and Abuse Contact
+                        if role.as_str() == "registrar" {
                             if let Some(public_ids) = &entity.public_ids {
                                 for public_id in public_ids {
                                     if let Some(id_type) = &public_id.id_type {
@@ -39,7 +69,7 @@ impl ToGtldWhois for Option<Vec<Entity>> {
                                             if id_type.as_str() == "IANA Registrar ID"
                                                 && !identifier.is_empty()
                                             {
-                                                front_formatted_data += &format!(
+                                                formatted_data += &format!(
                                                     "Registrar IANA ID: {}\n",
                                                     identifier.clone()
                                                 );
@@ -48,45 +78,14 @@ impl ToGtldWhois for Option<Vec<Entity>> {
                                     }
                                 }
                             }
-                            append_abuse_contact_info(entity, &mut front_formatted_data);
+                            append_abuse_contact_info(entity, &mut formatted_data);
                         }
-                        "technical" | "administrative" | "registrant" => {
-                            if let Some(vcard_array) = &entity.vcard_array {
-                                let role_info = extract_role_info(role, vcard_array, params);
-                                // Now use role_info to append to formatted_data
-                                if !role_info.name.is_empty() {
-                                    formatted_data +=
-                                        &format!("{} Name: {}\n", cfl(role), role_info.name);
-                                }
-                                if !role_info.org.is_empty() {
-                                    formatted_data +=
-                                        &format!("{} Organization: {}\n", cfl(role), role_info.org);
-                                }
-                                if !role_info.adr.is_empty() {
-                                    formatted_data += &role_info.adr;
-                                }
-                                if !role_info.email.is_empty() {
-                                    formatted_data +=
-                                        &format!("{} Email: {}\n", cfl(role), role_info.email);
-                                }
-                                if !role_info.phone.is_empty() {
-                                    formatted_data +=
-                                        &format!("{} Phone: {}\n", cfl(role), role_info.phone);
-                                }
-                                if !role_info.fax.is_empty() {
-                                    formatted_data +=
-                                        &format!("{} Fax: {}\n", cfl(role), role_info.fax);
-                                }
-                            }
-                        }
-                        _ => {} // Are there any roles we are missing?
                     }
                 }
             }
         }
 
-        front_formatted_data += &formatted_data;
-        front_formatted_data
+        formatted_data
     }
 }
 
@@ -138,7 +137,6 @@ fn format_address_with_label(
 }
 
 fn extract_role_info(
-    role: &str,
     vcard_array: &[serde_json::Value],
     params: &mut GtldParams,
 ) -> RoleInfo {
@@ -147,15 +145,6 @@ fn extract_role_info(
         None => return RoleInfo::default(),
     };
     let mut adr = String::new();
-    let label = match role {
-        "registrar" => "Registrar",
-        "technical" => "Technical",
-        "administrative" => "Admin",
-        "registrant" => "Registrant",
-        _ => "",
-    };
-    params.label = label.to_string();
-
     let name = contact.full_name.unwrap_or_default();
     let org = contact
         .organization_names
@@ -222,7 +211,7 @@ fn extract_role_info(
     }
 }
 
-fn append_abuse_contact_info(entity: &Entity, front_formatted_data: &mut String) {
+fn append_abuse_contact_info(entity: &Entity, formatted_data: &mut String) {
     if let Some(entities) = &entity.object_common.entities {
         for entity in entities {
             for role in entity.roles() {
@@ -234,7 +223,7 @@ fn append_abuse_contact_info(entity: &Entity, front_formatted_data: &mut String)
                                 for email in emails {
                                     let abuse_contact_email = &email.email;
                                     if !abuse_contact_email.is_empty() {
-                                        front_formatted_data.push_str(&format!(
+                                        formatted_data.push_str(&format!(
                                             "Registrar Abuse Contact Email: {}\n",
                                             abuse_contact_email
                                         ));
@@ -246,7 +235,7 @@ fn append_abuse_contact_info(entity: &Entity, front_formatted_data: &mut String)
                                 for phone in phones {
                                     let abuse_contact_phone = &phone.phone;
                                     if !abuse_contact_phone.is_empty() {
-                                        front_formatted_data.push_str(&format!(
+                                        formatted_data.push_str(&format!(
                                             "Registrar Abuse Contact Phone: {}\n",
                                             abuse_contact_phone
                                         ));
@@ -259,12 +248,4 @@ fn append_abuse_contact_info(entity: &Entity, front_formatted_data: &mut String)
             }
         }
     }
-}
-
-// capitalize first letter
-fn cfl(s: &str) -> String {
-    s.char_indices()
-        .next()
-        .map(|(i, c)| c.to_uppercase().collect::<String>() + &s[i + 1..])
-        .unwrap_or_default()
 }

--- a/icann-rdap-client/src/test_files/home.moscow-expected.gtld
+++ b/icann-rdap-client/src/test_files/home.moscow-expected.gtld
@@ -13,6 +13,7 @@ Registrar City:
 Registrar State/Province: 
 Registrar Postal Code: 
 Registrar Country: 
+Registrar Email: info@reg.ru
 Registrar IANA ID: 1606
 Registrar Abuse Contact Email: abuse@reg.ru
 Registrar Abuse Contact Phone: tel:+7

--- a/icann-rdap-client/src/test_files/lemonde.fr-expected.gtld
+++ b/icann-rdap-client/src/test_files/lemonde.fr-expected.gtld
@@ -10,23 +10,35 @@ Domain Status: server transfer prohibited
 Domain Status: server delete prohibited
 Domain Status: server recover prohibited
 Registrar Whois Server: whois.nameshield.net
+Sponsor: NAMESHIELD
+Sponsor Street: 39 boulevard des Capucines
+Sponsor City: PARIS
+Sponsor State/Province: 
+Sponsor Postal Code: 75002
+Sponsor Country: FR
+Sponsor Email: registrar@nameshield.net
+Sponsor Phone: +33.241182828
+Sponsor Fax: +33.241182829
 Registrar: NAMESHIELD
 Registrar Street: 39 boulevard des Capucines
 Registrar City: PARIS
 Registrar State/Province: 
 Registrar Postal Code: 75002
 Registrar Country: FR
+Registrar Email: registrar@nameshield.net
+Registrar Phone: +33.241182828
+Registrar Fax: +33.241182829
 Registrar IANA ID: 1251
-Technical Name: NAMESHIELD
-Technical Organization: TECHNICAL department
-Technical Street: 79 rue Desjardins
-Technical City: ANGERS
-Technical State/Province: 
-Technical Postal Code: 49100
-Technical Country: FR
-Technical Email: technical@nameshield.net
-Technical Phone: +33.241182828
-Technical Fax: +33.241182829
+Tech Name: NAMESHIELD
+Tech Organization: TECHNICAL department
+Tech Street: 79 rue Desjardins
+Tech City: ANGERS
+Tech State/Province: 
+Tech Postal Code: 49100
+Tech Country: FR
+Tech Email: technical@nameshield.net
+Tech Phone: +33.241182828
+Tech Fax: +33.241182829
 Registrant Name: SOCIETE EDITRICE du monde
 Registrant Organization: SOCIETE EDITRICE DU MONDE
 Registrant Street: 67-69 avenue Pierre Mendes-France
@@ -36,15 +48,15 @@ Registrant Postal Code: 75013
 Registrant Country: FR
 Registrant Email: domain_names@lemonde.fr
 Registrant Phone: +33.157282224
-Administrative Name: SOCIETE EDITRICE du monde
-Administrative Organization: SOCIETE EDITRICE DU MONDE
+Admin Name: SOCIETE EDITRICE du monde
+Admin Organization: SOCIETE EDITRICE DU MONDE
 Admin Street: 67-69 avenue Pierre Mendes-France
 Admin City: PARIS
 Admin State/Province: 
 Admin Postal Code: 75013
 Admin Country: FR
-Administrative Email: domain_names@lemonde.fr
-Administrative Phone: +33.157282224
+Admin Email: domain_names@lemonde.fr
+Admin Phone: +33.157282224
 Name Server: ns-cloud-b4.googledomains.com
 Name Server: ns-cloud-b2.googledomains.com
 Name Server: ns-cloud-b3.googledomains.com

--- a/icann-rdap-client/src/test_files/microsoft.click-expected.gtld
+++ b/icann-rdap-client/src/test_files/microsoft.click-expected.gtld
@@ -8,15 +8,6 @@ Updated Date: 2023-10-17T10:47:21.733Z
 Domain Status: client update prohibited
 Domain Status: client transfer prohibited
 Domain Status: client delete prohibited
-Registrar: MarkMonitor Inc.
-Registrar Street: 3540 East Longwing Lane, Suite 300
-Registrar City: Meridian
-Registrar State/Province: ID
-Registrar Postal Code: 83646
-Registrar Country: US
-Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
-Registrar Abuse Contact Phone: tel:+1.2083895740
-Registrar Abuse Contact Phone: tel:+1.2083895771
 Registrant Organization: Microsoft Corporation
 Registrant Street: 
 Registrant City: 
@@ -28,11 +19,23 @@ Admin City:
 Admin State/Province: 
 Admin Postal Code: 
 Admin Country: 
-Technical Street: 
-Technical City: 
-Technical State/Province: 
-Technical Postal Code: 
-Technical Country: 
+Tech Street: 
+Tech City: 
+Tech State/Province: 
+Tech Postal Code: 
+Tech Country: 
+Registrar: MarkMonitor Inc.
+Registrar Street: 3540 East Longwing Lane, Suite 300
+Registrar City: Meridian
+Registrar State/Province: ID
+Registrar Postal Code: 83646
+Registrar Country: US
+Registrar Email: ccops@markmonitor.com
+Registrar Phone: tel:+1.208389574
+Registrar Fax: tel:+1.2083895771
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: tel:+1.2083895740
+Registrar Abuse Contact Phone: tel:+1.2083895771
 Name Server: ns4-08.azure-dns.info
 Name Server: ns2-08.azure-dns.net
 Name Server: ns3-08.azure-dns.org


### PR DESCRIPTION
This PR add support for missing roles values in gTLD output mode as specified in [RFC 9083](https://datatracker.ietf.org/doc/html/rfc9083#sect-10.2.4) and the related [IANA registry](https://www.iana.org/assignments/rdap-json-values/rdap-json-values.xhtml):
 * billing
 * reseller
 * sponsor
 * proxy
 * notifications
 * noc

I’ve also renamed `technical` and `administrative` roles labels to `Tech` and `Admin` respectively in order to be more compliant with gTLD whois output as defined in the (previous version of) [ICANN registrar agreement](https://www.icann.org/en/contracted-parties/accredited-registrars/registrar-accreditation-agreement/2013-registrar-accreditation-agreement-08-06-2023-en#rdds.1.4.1.2).

I haven't updated the tests yet as I'm waiting for your comments.