### PR TITLE
feat(cli): add status-text and status-json outputs for primary object

### DIFF
--- a/icann-rdap-cli/src/bin/rdap/main.rs
+++ b/icann-rdap-cli/src/bin/rdap/main.rs
@@ -380,6 +380,12 @@ enum OtypeArg {
     /// URL of RDAP servers.
     Url,
 
+    /// Only print primary object's status, one per line.
+    StatusText,
+
+    /// Only print primary object's status as JSON.
+    StatusJson,
+
     /// Automatically determine the output type.
     Auto,
 }
@@ -530,6 +536,9 @@ pub async fn wrapped_main() -> Result<(), RdapCliError> {
         OtypeArg::JsonExtra => OutputType::JsonExtra,
         OtypeArg::GtldWhois => OutputType::GtldWhois,
         OtypeArg::Url => OutputType::Url,
+        OtypeArg::StatusText => OutputType::StatusText,
+        OtypeArg::StatusJson => OutputType::StatusJson,
+
     };
 
     let process_type = match cli.process_type {

--- a/icann-rdap-cli/tests/integration/rdap_cmd/queries.rs
+++ b/icann-rdap-cli/tests/integration/rdap_cmd/queries.rs
@@ -212,3 +212,73 @@ async fn GIVEN_domain_WHEN_search_domain_names_THEN_success() {
     let assert = test_jig.cmd.assert();
     assert.success();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn GIVEN_domain_with_statuses_WHEN_output_status_text_THEN_only_status_lines() {
+    // GIVEN
+    let mut test_jig = TestJig::new_rdap().await;
+    let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
+    tx.add_domain(
+        &Domain::builder()
+            .ldh_name("foo.example")
+            .status("client delete prohibited")
+            .status("client transfer prohibited")
+            .status("client update prohibited")
+            .build(),
+    )
+    .await
+    .expect("add domain in tx");
+    tx.commit().await.expect("tx commit");
+
+    // WHEN
+    test_jig
+        .cmd
+        .arg("foo.example")
+        .arg("-O")
+        .arg("status-text")
+        .arg("-L")
+        .arg("off");
+
+    // THEN
+    let assert = test_jig.cmd.assert();
+    assert
+        .success()
+        .stdout(
+            "client delete prohibited\nclient transfer prohibited\nclient update prohibited\n",
+        );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn GIVEN_domain_with_statuses_WHEN_output_status_json_THEN_only_status_json() {
+    // GIVEN
+    let mut test_jig = TestJig::new_rdap().await;
+    let mut tx = test_jig.mem.new_tx().await.expect("new transaction");
+    tx.add_domain(
+        &Domain::builder()
+            .ldh_name("bar.example")
+            .status("client delete prohibited")
+            .status("client transfer prohibited")
+            .status("client update prohibited")
+            .build(),
+    )
+    .await
+    .expect("add domain in tx");
+    tx.commit().await.expect("tx commit");
+
+    // WHEN
+    test_jig
+        .cmd
+        .arg("bar.example")
+        .arg("-O")
+        .arg("status-json")
+        .arg("-L")
+        .arg("off");
+
+    // THEN
+    let assert = test_jig.cmd.assert();
+    assert
+        .success()
+        .stdout(
+            "{\"status\":[\"client delete prohibited\",\"client transfer prohibited\",\"client update prohibited\"]}\n",
+        );
+}


### PR DESCRIPTION
Issue #, if available: https://github.com/icann/icann-rdap/issues/3

Description of changes:
- Adds two outputs: -O status-text and -O status-json
- Prints only the primary object’s status (single result)
- status-text: one line per status; status-json: {"status":[...]} (empty when none)
- Aligned with other final-phase outputs; integration tests included