### PR TITLE
Refs #177 No JSON output when HTTP errors occur

### DIFF
--- a/icann-rdap-cli/src/bin/rdap/query.rs
+++ b/icann-rdap-cli/src/bin/rdap/query.rs
@@ -199,7 +199,8 @@ pub(crate) async fn exec_queries<W: std::io::Write>(
                 if req_number == 1 {
                     return Err(RdapCliError::NoRegistryFound);
                 } else {
-                    return Err(error);
+                    warn!("{error}");
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Continue query-loop and warn so that JSON output types are emitted